### PR TITLE
Add a hlt hook to prevent infinite-loop.

### DIFF
--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -183,6 +183,15 @@ void StaticOpcodeHook(void *Context, uint32_t Id, const void *i,
                                                              is32, is64);
 }
 
+void StaticHltHook(void *Context, uint32_t Cpu) {
+
+  //
+  // Invoking the member function now.
+  //
+
+  reinterpret_cast<BochscpuBackend_t *>(Context)->OpcodeHlt(Cpu);
+}
+
 BochscpuBackend_t::BochscpuBackend_t() {
 
   //
@@ -224,6 +233,7 @@ bool BochscpuBackend_t::Initialize(const Options_t &Opts,
   Hooks_.exception = StaticExceptionHook;
   Hooks_.phy_access = StaticPhyAccessHook;
   Hooks_.tlb_cntrl = StaticTlbControlHook;
+  Hooks_.hlt = StaticHltHook;
   // Hooks_.opcode = StaticOpcodeHook;
 
   //
@@ -599,6 +609,15 @@ void BochscpuBackend_t::OpcodeHook(/*void *Context, */ uint32_t,
 #undef BX_IA_CMP_AXIw
 #undef BX_IA_CMP_EwIw
 #undef BX_IA_CMP_EwsIb
+}
+
+void BochscpuBackend_t::OpcodeHlt(/*void *Context, */ uint32_t) {
+  fmt::print("The emulator ran into a triple-fault exception or hit a HLT "
+             "instruction.\n");
+  fmt::print("If this is not an HLT instruction, please report it as a bug!\n");
+  fmt::print("Stopping the cpu.\n");
+  TestcaseResult_ = Crash_t();
+  bochscpu_cpu_stop(Cpu_);
 }
 
 bool BochscpuBackend_t::Restore(const CpuState_t &CpuState) {

--- a/src/wtf/bochscpu_backend.h
+++ b/src/wtf/bochscpu_backend.h
@@ -287,9 +287,12 @@ public:
 
   virtual void TlbControlHook(/*void *Context, */ uint32_t Id, uint32_t What,
                               uint64_t NewCrValue);
+
   virtual void OpcodeHook(/*void *Context, */ uint32_t Id, const void *Ins,
                           const uint8_t *Opcode, uintptr_t Len, bool Is32,
                           bool Is64);
+
+  virtual void OpcodeHlt(/*void *Context, */ uint32_t Cpu);
 
 private:
   //


### PR DESCRIPTION
In #22 an invalid `tr` segment register lead the CPU to run into an infinite loop when it tries to read `rsp` off the task state segment. This PR adds an `HLT` hook to mitigate those type of issues by stopping the CPU with a message documenting this case.