### PR TITLE
fix bochs backend segment flags

### DIFF
--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -972,9 +972,13 @@ void BochscpuBackend_t::LoadState(const CpuState_t &State) {
   Bochs.mxcsr_mask = State.MxcsrMask;
   Bochs.fpop = State.Fpop;
 
+// bdump does not include the limit bits in the attributes, bochs does
+// so the attributes need to be shifted for the upper flags (G, D/B, L, AVL) 
+// to be in the correct places
 #define SEG(_Bochs_, _Whv_)                                                    \
   {                                                                            \
-    Bochs._Bochs_.attr = State._Whv_.Attr;                                     \
+    Bochs._Bochs_.attr = (State._Whv_.Attr & 0xFF) |                           \
+      ((State._Whv_.Attr & 0xF00) << 4);                                       \
     Bochs._Bochs_.base = State._Whv_.Base;                                     \
     Bochs._Bochs_.limit = State._Whv_.Limit;                                   \
     Bochs._Bochs_.present = State._Whv_.Present;                               \


### PR DESCRIPTION
hi,
it looks like bochs expects the limit bits in the segment register attr field to be present (though it doesn't seem to use them).
If you use bdump to get segment flags it dumps out just the flags with the upper bits (G, D/B, L, AVL) shifted down by 4 bits. However, when loading the state into bochs it does not expect them to be shifted so they are loaded incorrectly.
ex. it shifts by 14 to get the D/B flag [(see here)](https://github.com/lubomyr/bochs/blob/master/cpu/segment_ctrl_pro.cc#L391)

I ran into this issue trying to fuzz code running under wow64. Since segment registers are less used in 64bit, the problem is mostly avoided. However, running in IA-32 compatibility mode runs into issues almost immediately because the correct bits are not set. I was incorrectly executing in 16-bit mode because D/B was not set when it should have been. This is what led me to track down the issue. This PR fixes the issue and now fuzzing sessions in wow64 are working as expected. 

As a side note bdump sets the L bit in the flags for the cs register no matter what, which obviously breaks IA-32 compatibility emulation since the processor will execute in 64-bit mode with that bit set. I just commented that section out of bdump, but might be worth mentioning somewhere in the readme for this tool. I'll leave that up to you :)