### PR TITLE
Copy dbgeng/dbgcore.dll so that the distribution works on Win11

### DIFF
--- a/.github/workflows/wtf.yml
+++ b/.github/workflows/wtf.yml
@@ -52,6 +52,8 @@ jobs:
       if: matrix.generator == 'ninja'
       run: |
         copy "c:\program Files (x86)\windows kits\10\debuggers\x64\dbghelp.dll" src/build
+        copy "c:\program Files (x86)\windows kits\10\debuggers\x64\dbgeng.dll" src/build
+        copy "c:\program Files (x86)\windows kits\10\debuggers\x64\dbgcore.dll" src/build
         copy "c:\program Files (x86)\windows kits\10\debuggers\x64\symsrv.dll" src/build
 
     - name: Upload artifacts

--- a/.github/workflows/wtf.yml
+++ b/.github/workflows/wtf.yml
@@ -65,6 +65,8 @@ jobs:
           src/build/wtf.exe
           src/build/wtf.pdb
           src/build/dbghelp.dll
+          src/build/dbgeng.dll
+          src/build/dbgcore.dll
           src/build/symsrv.dll
 
   Linux:


### PR DESCRIPTION
This PR fixes #31 by including both dbgeng.dll & dbgcore.dll in the CI artifacts as well as in wtf's current directory.