### PR TITLE
Warn user if @cr3 is not page aligned and then align

### DIFF
--- a/src/wtf/utils.cc
+++ b/src/wtf/utils.cc
@@ -215,6 +215,16 @@ bool SanitizeCpuState(CpuState_t &CpuState) {
     }
   }
 
+  //
+  // Check if the CR3 is page aligned.
+  //
+
+  const Gpa_t Cr3(CpuState.Cr3);
+  if (Cr3.Align() != Cr3) {
+    fmt::print("@cr3 ({:x}) is not aligned.. aligning it.\n");
+    CpuState.Cr3 = Cr3.Align().U64();
+  }
+
   return true;
 }
 

--- a/src/wtf/utils.cc
+++ b/src/wtf/utils.cc
@@ -221,7 +221,7 @@ bool SanitizeCpuState(CpuState_t &CpuState) {
 
   const Gpa_t Cr3(CpuState.Cr3);
   if (Cr3.Align() != Cr3) {
-    fmt::print("@cr3 ({:x}) is not aligned.. aligning it.\n");
+    fmt::print("The @cr3 ({:x}) register is not aligned.. aligning it.\n", Cr3);
     CpuState.Cr3 = Cr3.Align().U64();
   }
 


### PR DESCRIPTION
This PR warns the user when the `@cr3` register is not page aligned and will align it before going forward (cf #41).