### PR TITLE
Fix bug in client metrics

### DIFF
--- a/src/wtf/client.cc
+++ b/src/wtf/client.cc
@@ -115,11 +115,14 @@ TestcaseResult_t RunTestcaseAndRestore(const Target_t &Target,
   }
 
   //
-  // Let know the stats that we finished a testcase.
+  // Let know the stats that we finished a testcase. Make sure to not count
+  // coverage if the testcase timed-out as it'll get revoked.
   //
 
-  const auto &LastNewCoverage = g_Backend->LastNewCoverage();
-  g_Stats.TestcaseEnds(*Res, LastNewCoverage.size());
+  const bool Timedout = std::holds_alternative<Timedout_t>(*Res);
+  const uint64_t NewCoverage =
+      Timedout ? 0 : g_Backend->LastNewCoverage().size();
+  g_Stats.TestcaseEnds(*Res, NewCoverage);
 
   //
   // Let the stats that we are about to start a restore.


### PR DESCRIPTION
This PR fixes #51 - the issue that happend is the below:

1. A testcase that generates new coverage but times out
2. The code grabbed the last new coverage, and added the amount of new coverage to the coverage counter
3. As the testcase timed-out, this coverage is asked to be revoked

Now let's say the same testcase runs again, retriggers this new coverage but times out; the amount of 'new' coverage gets added again even though it'll get reverted. This happening a large number of times lead to the coverage count being completely inacurrate on the client side.