### PR TITLE
Client does not need TestcaseBufferMaxSize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The client nodes run a test-case that has been generated and distributed by the 
 This is how you would start a client node that uses the *bochscpu* backend:
 
 ```text
-..\..\src\build\wtf.exe fuzz --backend=bochscpu --name hevd --max_len 1028 --limit 10000000
+..\..\src\build\wtf.exe fuzz --backend=bochscpu --name hevd --limit 10000000
 ```
 
 The `fuzz` subcommand is used with the `name` option to specify which fuzzer module needs to be used, `backend` specifies the execution backend and `limit` the maximum number of instruction to execute per testcase (depending on the backend, this option has different meaning).

--- a/src/wtf/globals.h
+++ b/src/wtf/globals.h
@@ -1195,12 +1195,6 @@ struct FuzzOptions_t {
   fs::path TargetPath;
 
   //
-  // The maximum size of a generated testcase.
-  //
-
-  uint64_t TestcaseBufferMaxSize = 0;
-
-  //
   // Seed for RNG.
   //
 

--- a/src/wtf/wtf.cc
+++ b/src/wtf/wtf.cc
@@ -296,12 +296,6 @@ int main(int argc, const char *argv[]) {
       ->description(
           "Target directory which contains state/ inputs/ outputs/ folders.");
 
-  FuzzCmd
-      ->add_option("--max_len", Opts.Fuzz.TestcaseBufferMaxSize,
-                   "Testcase size")
-      ->description("Maximum size of a generated testcase.")
-      ->required();
-
   FuzzCmd->add_option("--limit", Opts.Limit, "Limit")
       ->description("Limit per testcase (instruction count for bochscpu, time "
                     "in second for whv).");


### PR DESCRIPTION
This option used to be necessary to be able to allocate a buffer big enough to receive the testcase / mutate it in place but as found in #65 is no longer used.