### PR TITLE
Fix missing symbol format args when caching symbol name

### DIFF
--- a/src/wtf/debugger.h
+++ b/src/wtf/debugger.h
@@ -336,7 +336,7 @@ public:
       Offset = SymbolAddress - Base;
     }
 
-    SymbolCache_.emplace(SymbolAddress, fmt::format("{}+{:#x}"));
+    SymbolCache_.emplace(SymbolAddress, fmt::format("{}+{:#x}", Buffer, Offset));
     return SymbolCache_.at(SymbolAddress);
   }
 };


### PR DESCRIPTION
Wrote a fuzzer that needed to fetch a symbol name using `GetName()` (which is otherwise unused) and ran into this issue.

P.S. This project is awesome, many thanks for maintaining it 🍻 