### PR TITLE
Adjust DebugPrint macro for fmt >= 8

### DIFF
--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -13,7 +13,7 @@ constexpr bool BochsHooksLoggingOn = false;
 
 template <typename... Args_t>
 void BochsDebugPrint(const char *Format, const Args_t &...args) {
-  if constexpr (BochsLoggingOn) {
+  if (BochsLoggingOn) {
     fmt::print("bochs: ");
     fmt::print(Format, args...);
   }
@@ -21,7 +21,7 @@ void BochsDebugPrint(const char *Format, const Args_t &...args) {
 
 template <typename... Args_t>
 void BochsHooksDebugPrint(const char *Format, const Args_t &...args) {
-  if constexpr (BochsHooksLoggingOn) {
+  if (BochsHooksLoggingOn) {
     fmt::print("bochshooks: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -15,7 +15,7 @@ template <typename... Args_t>
 void BochsDebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (BochsLoggingOn) {
     fmt::print("bochs: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 
@@ -23,7 +23,7 @@ template <typename... Args_t>
 void BochsHooksDebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (BochsHooksLoggingOn) {
     fmt::print("bochshooks: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -13,7 +13,7 @@ constexpr bool BochsHooksLoggingOn = false;
 
 template <typename... Args_t>
 void BochsDebugPrint(const char *Format, const Args_t &...args) {
-  if (BochsLoggingOn) {
+  if constexpr (BochsLoggingOn) {
     fmt::print("bochs: ");
     fmt::print(Format, args...);
   }
@@ -21,7 +21,7 @@ void BochsDebugPrint(const char *Format, const Args_t &...args) {
 
 template <typename... Args_t>
 void BochsHooksDebugPrint(const char *Format, const Args_t &...args) {
-  if (BochsHooksLoggingOn) {
+  if constexpr (BochsHooksLoggingOn) {
     fmt::print("bochshooks: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/crash_detection_umode.cc
+++ b/src/wtf/crash_detection_umode.cc
@@ -11,7 +11,7 @@ constexpr bool UCrashDetectionLoggingOn = false;
 
 template <typename... Args_t>
 void CrashDetectionPrint(const char *Format, const Args_t &...args) {
-  if constexpr (UCrashDetectionLoggingOn) {
+  if (UCrashDetectionLoggingOn) {
     fmt::print("ucrash: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/crash_detection_umode.cc
+++ b/src/wtf/crash_detection_umode.cc
@@ -13,7 +13,7 @@ template <typename... Args_t>
 void CrashDetectionPrint(const char *Format, const Args_t &...args) {
   if constexpr (UCrashDetectionLoggingOn) {
     fmt::print("ucrash: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 

--- a/src/wtf/crash_detection_umode.cc
+++ b/src/wtf/crash_detection_umode.cc
@@ -11,7 +11,7 @@ constexpr bool UCrashDetectionLoggingOn = false;
 
 template <typename... Args_t>
 void CrashDetectionPrint(const char *Format, const Args_t &...args) {
-  if (UCrashDetectionLoggingOn) {
+  if constexpr (UCrashDetectionLoggingOn) {
     fmt::print("ucrash: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/fuzzer_hevd.cc
+++ b/src/wtf/fuzzer_hevd.cc
@@ -11,7 +11,7 @@ constexpr bool LoggingOn = false;
 
 template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
-  if (LoggingOn) {
+  if constexpr (LoggingOn) {
     fmt::print("Hevd: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/fuzzer_hevd.cc
+++ b/src/wtf/fuzzer_hevd.cc
@@ -13,7 +13,7 @@ template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (LoggingOn) {
     fmt::print("Hevd: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 

--- a/src/wtf/fuzzer_hevd.cc
+++ b/src/wtf/fuzzer_hevd.cc
@@ -11,7 +11,7 @@ constexpr bool LoggingOn = false;
 
 template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
-  if constexpr (LoggingOn) {
+  if (LoggingOn) {
     fmt::print("Hevd: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/fuzzer_tlv_server.cc
+++ b/src/wtf/fuzzer_tlv_server.cc
@@ -17,7 +17,7 @@ template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (LoggingOn) {
     fmt::print("tlv_server: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 

--- a/src/wtf/fuzzer_tlv_server.cc
+++ b/src/wtf/fuzzer_tlv_server.cc
@@ -15,7 +15,7 @@ constexpr bool LoggingOn = false;
 
 template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
-  if (LoggingOn) {
+  if constexpr (LoggingOn) {
     fmt::print("tlv_server: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/fuzzer_tlv_server.cc
+++ b/src/wtf/fuzzer_tlv_server.cc
@@ -15,7 +15,7 @@ constexpr bool LoggingOn = false;
 
 template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
-  if constexpr (LoggingOn) {
+  if (LoggingOn) {
     fmt::print("tlv_server: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -26,7 +26,7 @@ template <typename... Args_t>
 void KvmDebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (KvmLoggingOn) {
     fmt::print("kvm: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -24,7 +24,7 @@ constexpr bool KvmLoggingOn = false;
 
 template <typename... Args_t>
 void KvmDebugPrint(const char *Format, const Args_t &...args) {
-  if (KvmLoggingOn) {
+  if constexpr (KvmLoggingOn) {
     fmt::print("kvm: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -24,7 +24,7 @@ constexpr bool KvmLoggingOn = false;
 
 template <typename... Args_t>
 void KvmDebugPrint(const char *Format, const Args_t &...args) {
-  if constexpr (KvmLoggingOn) {
+  if (KvmLoggingOn) {
     fmt::print("kvm: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/whv_backend.cc
+++ b/src/wtf/whv_backend.cc
@@ -13,7 +13,7 @@ template <typename... Args_t>
 void WhvDebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (WhvLoggingOn) {
     fmt::print("whv: ");
-    fmt::print(Format, args...);
+    fmt::print(fmt::runtime(Format), args...);
   }
 }
 

--- a/src/wtf/whv_backend.cc
+++ b/src/wtf/whv_backend.cc
@@ -11,7 +11,7 @@ constexpr bool WhvLoggingOn = false;
 
 template <typename... Args_t>
 void WhvDebugPrint(const char *Format, const Args_t &...args) {
-  if (WhvLoggingOn) {
+  if constexpr (WhvLoggingOn) {
     fmt::print("whv: ");
     fmt::print(Format, args...);
   }

--- a/src/wtf/whv_backend.cc
+++ b/src/wtf/whv_backend.cc
@@ -11,7 +11,7 @@ constexpr bool WhvLoggingOn = false;
 
 template <typename... Args_t>
 void WhvDebugPrint(const char *Format, const Args_t &...args) {
-  if constexpr (WhvLoggingOn) {
+  if (WhvLoggingOn) {
     fmt::print("whv: ");
     fmt::print(Format, args...);
   }


### PR DESCRIPTION
This PR fixes #62 by adjusting the `DebugPrint` macros because of c++20 & a change in the version 8 of fmtlib; quoting https://github.com/scylladb/seastar/commit/dfb62861f3d120a9c52a633ba9304a35197ea001:
> fmt 8.0.0 changes the default behavior of `fmt::format_to` and some other functions to utilize `consteval` C++20 feature.
> Now, format strings are always assumed to be constant evaluated in C++20 mode. Otherwise, an explicit `fmt::runtime()` call to wrap the format string is required.
