### PR TITLE
Check the size of the RAM to avoid underflow

### DIFF
--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -1210,7 +1210,7 @@ bool KvmBackend_t::PopulateMemory(const Options_t &Opts) {
 
   const uint64_t Gpa = First.memory_size + Page::Size;
   if (Ram_.Size() <= Gpa) {
-    perror("The RAM size is smaller than what is expected");
+    perror("The RAM size is smaller than expected");
     return false;
   }
 

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -1209,6 +1209,11 @@ bool KvmBackend_t::PopulateMemory(const Options_t &Opts) {
   //
 
   const uint64_t Gpa = First.memory_size + Page::Size;
+  if (Ram_.Size() <= Gpa) {
+    perror("The RAM size is smaller than what is expected");
+    return false;
+  }
+
   const struct kvm_userspace_memory_region Second = {
       .slot = 1,
       .flags = KVM_MEM_LOG_DIRTY_PAGES,


### PR DESCRIPTION
This PR fixes #73 by simply bailing if the snapshotted guest has less than 4GB of RAM - it is not a configuration that's been tested.