### PR TITLE
add 32bit function return simulate

### DIFF
--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -145,6 +145,25 @@ bool Backend_t::SimulateReturnFromFunction(const uint64_t Return) {
   return true;
 }
 
+bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount=0) {
+  //
+  // Set return value.
+  //
+
+  Rax(Return);
+
+  const uint64_t Stack = Rsp();
+  const uint32_t SavedReturnAddress = VirtRead4(Gva_t(Stack));
+
+  //
+  // Eat up the saved return address.
+  //
+
+  Rsp(Stack + (4 + (4 * stdcallArgsCount)));
+  Rip(SavedReturnAddress);
+  return true;
+}
+
 uint64_t Backend_t::GetArg(const uint64_t Idx) {
   switch (Idx) {
   case 0:

--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -145,7 +145,7 @@ bool Backend_t::SimulateReturnFromFunction(const uint64_t Return) {
   return true;
 }
 
-bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount) {
+bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t StdcallArgsCount) {
   //
   // Set return value.
   //
@@ -159,7 +159,7 @@ bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uin
   // Eat up the saved return address.
   //
 
-  Rsp(Stack + (4 + (4 * stdcallArgsCount)));
+  Rsp(Stack + (4 + (4 * StdcallArgsCount)));
   Rip(SavedReturnAddress);
   return true;
 }

--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -145,7 +145,7 @@ bool Backend_t::SimulateReturnFromFunction(const uint64_t Return) {
   return true;
 }
 
-bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount=0) {
+bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount) {
   //
   // Set return value.
   //

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -481,7 +481,7 @@ public:
   //
 
   bool SimulateReturnFromFunction(const uint64_t Return);
-  bool SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount=0);
+  bool SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t StdcallArgsCount = 0);
 
   //
   // Utility function that grabs function arguments according to the Windows x64

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -481,7 +481,7 @@ public:
   //
 
   bool SimulateReturnFromFunction(const uint64_t Return);
-  bool SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount);
+  bool SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount=0);
 
   //
   // Utility function that grabs function arguments according to the Windows x64

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -481,6 +481,7 @@ public:
   //
 
   bool SimulateReturnFromFunction(const uint64_t Return);
+  bool SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t stdcallArgsCount);
 
   //
   // Utility function that grabs function arguments according to the Windows x64


### PR DESCRIPTION
I fuzz some 32bit binaries recently.

During fuzzing, I found that `SimulateReturnFromFunction` is not fit for 32 bit binary function's attribute( `__cdecl`, `__stdcall` ).
So, I add some code for that.