### PR TITLE
KVM Windows Virtual Address Translation

### DIFF
--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -87,6 +87,52 @@ union MMPTE_HARDWARE {
   }
 };
 
+
+union MMPTE_SOFTWARE {
+  struct {
+    uint64_t Present : 1;
+    uint64_t PageFileReserved : 1;
+    uint64_t PageFileAllocated : 1;
+    uint64_t ColdPage : 1;
+    uint64_t SwizzleBit : 1;
+    uint64_t Protection : 5;
+    uint64_t Prototype : 1;
+    uint64_t Transition : 1;
+    uint64_t PageFileLow : 4;
+    uint64_t UsedPageTableEntries : 10;
+    uint64_t ShadowStack : 1;
+    uint64_t Unused : 5;
+    uint64_t PageFileHigh : 32;
+  };
+  uint64_t AsUINT64;
+  MMPTE_SOFTWARE(const uint64_t Value) : AsUINT64(Value) {}
+};
+
+union MMPTE_PROTOTYPE {
+  struct {
+    uint64_t Present : 1;
+    uint64_t DemandFillProto : 1;
+    uint64_t HiberVerifyConverted : 1;
+    uint64_t ReadOnly : 1;
+    uint64_t SwizzleBit : 1;
+    uint64_t Protection : 5;
+    uint64_t Prototype : 1;
+    uint64_t Combined : 1;
+    uint64_t Unused : 4;
+    uint64_t ProtoAddress : 48;
+  };
+  uint64_t AsUINT64;
+  MMPTE_PROTOTYPE(const uint64_t Value) : AsUINT64(Value) {}
+};
+
+union MMPTE {
+    MMPTE_HARDWARE hard;
+    MMPTE_SOFTWARE soft;
+    MMPTE_PROTOTYPE proto;
+    uint64_t AsUINT64;
+    MMPTE(const uint64_t Value) : AsUINT64(Value) {}
+};
+
 //
 // Structure to parse a virtual address.
 //
@@ -247,6 +293,13 @@ public:
 
   virtual bool VirtTranslate(const Gva_t Gva, Gpa_t &Gpa,
                              const MemoryValidate_t Validate) const = 0;
+
+  //
+  // GVA->GPA translation with page fault insertion if needed.
+  //
+
+  virtual bool VirtTranslateWithPF(const Gva_t Gva, Gpa_t &Gpa,
+                                   const MemoryValidate_t Validate) = 0;
 
   //
   // GPA->HVA translation.

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -792,6 +792,11 @@ bool BochscpuBackend_t::VirtTranslate(const Gva_t Gva, Gpa_t &Gpa,
   return Gpa != Gpa_t(0xffffffffffffffff);
 }
 
+bool BochscpuBackend_t::VirtTranslateWithPF(const Gva_t Gva, Gpa_t &Gpa,
+                                            const MemoryValidate_t Validate) {
+    return BochscpuBackend_t::VirtTranslate(Gva, Gpa, Validate);
+}
+
 uint8_t *BochscpuBackend_t::PhysTranslate(const Gpa_t Gpa) const {
   return bochscpu_mem_phy_translate(Gpa.U64());
 }

--- a/src/wtf/bochscpu_backend.h
+++ b/src/wtf/bochscpu_backend.h
@@ -253,6 +253,9 @@ public:
   bool VirtTranslate(const Gva_t Gva, Gpa_t &Gpa,
                      const MemoryValidate_t Validate) const override;
 
+  bool VirtTranslateWithPF(const Gva_t Gva, Gpa_t &Gpa,
+                           const MemoryValidate_t Validate) override;
+
   uint8_t *PhysTranslate(const Gpa_t Gpa) const override;
 
   bool PageFaultsMemoryIfNeeded(const Gva_t Gva, const uint64_t Size) override;

--- a/src/wtf/utils.cc
+++ b/src/wtf/utils.cc
@@ -273,7 +273,7 @@ std::string u16stringToString(const std::u16string &S) {
 }
 
 std::optional<tsl::robin_map<Gva_t, Gpa_t>>
-ParseCovFiles(const Backend_t &Backend, const fs::path &CovFilesDir) {
+ParseCovFiles(Backend_t &Backend, const fs::path &CovFilesDir) {
   tsl::robin_map<Gva_t, Gpa_t> CovBreakpoints;
 
   //
@@ -312,7 +312,7 @@ ParseCovFiles(const Backend_t &Backend, const fs::path &CovFilesDir) {
       //
 
       Gpa_t Gpa;
-      const bool Translate = Backend.VirtTranslate(
+      const bool Translate = Backend.VirtTranslateWithPF(
           Gva, Gpa, MemoryValidate_t::ValidateReadExecute);
 
       if (!Translate) {

--- a/src/wtf/utils.h
+++ b/src/wtf/utils.h
@@ -246,7 +246,7 @@ const uint64_t _1MB = _1KB * _1KB;
 //
 
 [[nodiscard]] std::optional<tsl::robin_map<Gva_t, Gpa_t>>
-ParseCovFiles(const Backend_t &Backend, const fs::path &CovBreakpointFile);
+ParseCovFiles(Backend_t &Backend, const fs::path &CovBreakpointFile);
 
 //
 // Save a file on disk.

--- a/src/wtf/whv_backend.cc
+++ b/src/wtf/whv_backend.cc
@@ -747,6 +747,11 @@ bool WhvBackend_t::VirtTranslate(const Gva_t Gva, Gpa_t &Gpa,
   return TranslationResult.ResultCode == WHvTranslateGvaResultSuccess;
 }
 
+bool WhvBackend_t::VirtTranslateWithPF(const Gva_t Gva, Gpa_t &Gpa,
+                                       const MemoryValidate_t Validate) {
+    return WhvBackend_t::VirtTranslate(Gva, Gpa, Validate);
+}
+
 bool WhvBackend_t::PhysRead(const Gpa_t Gpa, uint8_t *Buffer,
                             const uint64_t BufferSize) const {
   const uint8_t *Src = PhysTranslate(Gpa);

--- a/src/wtf/whv_backend.h
+++ b/src/wtf/whv_backend.h
@@ -295,6 +295,9 @@ public:
   bool VirtTranslate(const Gva_t Gva, Gpa_t &Gpa,
                      const MemoryValidate_t Validate) const override;
 
+ bool VirtTranslateWithPF(const Gva_t Gva, Gpa_t &Gpa,
+                          const MemoryValidate_t Validate) override;
+
   uint8_t *PhysTranslate(const Gpa_t Gpa) const override;
 
   bool PageFaultsMemoryIfNeeded(const Gva_t Gva, const uint64_t Size) override;


### PR DESCRIPTION
Implement VAT to allow the KVM backend to set  breakpoints on pages that are in the dump but still in transition.

Might be useful as an alternative or a complement to memlock.

PR based on our work on [IceBox](https://github.com/thalium/icebox): https://thalium.github.io/blog/posts/windows-full-memory-introspection-with-icebox/