### PR TITLE
Update CI to `checkout` & `upload-artifact`

### DIFF
--- a/.github/workflows/wtf.yml
+++ b/.github/workflows/wtf.yml
@@ -18,7 +18,7 @@ jobs:
     name: Windows latest / ${{ matrix.generator }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload artifacts
       if: matrix.generator == 'ninja'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: bin-win64.RelWithDebInfo
         path: |
@@ -79,7 +79,7 @@ jobs:
     name: Ubuntu latest / ${{ matrix.compiler }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -116,7 +116,7 @@ jobs:
       uses: github/codeql-action/analyze@v2
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: bin-lin64-${{ matrix.compiler }}.Release
         path: |


### PR DESCRIPTION
Use `v3` instead of `v2` to get rid of those warnings:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2
```