### PR TITLE
Fix memory performance issue related to `aligned_alloc`

### DIFF
--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -70,8 +70,15 @@ void StaticGpaMissingHandler(const uint64_t Gpa) {
   // (0000022ed2ae7000 + 00000738).
   //
 
-  uint8_t *Page = (uint8_t *)aligned_alloc(Page::Size, Page::Size);
+#if defined WINDOWS
+  uint8_t *Page = (uint8_t *)VirtualAlloc(
+      nullptr, Page::Size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
   if (Page == nullptr) {
+#elif defined LINUX
+  uint8_t *Page =
+      mmap(nullptr, Page::Size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
+  if (Page == (void *)-1) {
+#endif
     fmt::print("Failed to allocate memory in GpaMissingHandler.\n");
     __debugbreak();
   }

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -75,8 +75,8 @@ void StaticGpaMissingHandler(const uint64_t Gpa) {
       nullptr, Page::Size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
   if (Page == nullptr) {
 #elif defined LINUX
-  uint8_t *Page =
-      mmap(nullptr, Page::Size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
+  uint8_t *Page = (uint8_t *)mmap(nullptr, Page::Size, PROT_READ | PROT_WRITE,
+                                  MAP_ANONYMOUS, -1, 0);
   if (Page == (void *)-1) {
 #endif
     fmt::print("Failed to allocate memory in GpaMissingHandler.\n");

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -71,12 +71,42 @@ void StaticGpaMissingHandler(const uint64_t Gpa) {
   //
 
 #if defined WINDOWS
-  uint8_t *Page = (uint8_t *)VirtualAlloc(
-      nullptr, Page::Size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+
+  //
+  // VirtualAlloc is able to give us back page-aligned allocation, but every
+  // time we allocate 1 page, the allocator actually reserve a 64KB region of VA
+  // and we'll use the first page of that. This basically fragment the
+  // address-space, so what we do is we actually reserve a 64KB region, and
+  // we'll commit pages as we need them.
+  //
+
+  static size_t Left = 0;
+  static uint8_t *Current = nullptr;
+  if (Left == 0) {
+
+    //
+    // It's time to reserve a 64KB region.
+    //
+
+    const uint64_t _64KB = 1024 * 64;
+    Left = _64KB;
+    Current =
+        (uint8_t *)VirtualAlloc(nullptr, Left, MEM_RESERVE, PAGE_READWRITE);
+  }
+
+  //
+  // Commit a page off the reserved region.
+  //
+
+  uint8_t *Page =
+      (uint8_t *)VirtualAlloc(Current, Page::Size, MEM_COMMIT, PAGE_READWRITE);
+
+  Left -= Page::Size;
+  Current += Page::Size;
   if (Page == nullptr) {
 #elif defined LINUX
   uint8_t *Page = (uint8_t *)mmap(nullptr, Page::Size, PROT_READ | PROT_WRITE,
-                                  MAP_ANONYMOUS, -1, 0);
+                                  MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   if (Page == (void *)-1) {
 #endif
     fmt::print("Failed to allocate memory in GpaMissingHandler.\n");

--- a/src/wtf/platform.h
+++ b/src/wtf/platform.h
@@ -18,8 +18,6 @@ using ssize_t = SSIZE_T;
 #define __builtin_bswap16 _byteswap_ushort
 #define __builtin_bswap32 _byteswap_ulong
 #define __builtin_bswap64 _byteswap_uint64
-#define aligned_alloc(a, b) _aligned_malloc(a, b)
-#define aligned_free(x) _aligned_free(x)
 #if defined ARCH_X86
 #define WINDOWS_X86
 #elif defined ARCH_X64

--- a/src/wtf/ram.h
+++ b/src/wtf/ram.h
@@ -74,7 +74,7 @@ public:
 
   ~Ram_t() {
     for (const auto &[_, Page] : Cache_) {
-      aligned_free(Page);
+      free(Page);
     }
 
     if (Ram_ != nullptr) {
@@ -172,7 +172,7 @@ public:
     //
 
     else {
-      Page = (uint8_t *)aligned_alloc(Page::Size, Page::Size);
+      Page = (uint8_t *)malloc(Page::Size);
       if (Page == nullptr) {
         fmt::print("Failed to call aligned_alloc.\n");
         return nullptr;
@@ -302,7 +302,7 @@ public:
 
 private:
   //
-  // Get an HVA fora GPA by looking at our cache.
+  // Get an HVA for a GPA by looking at our cache.
   //
 
   [[nodiscard]] uint8_t *GetHvaFromCache(const Gpa_t Gpa) {

--- a/src/wtf/ram.h
+++ b/src/wtf/ram.h
@@ -174,7 +174,7 @@ public:
     else {
       Page = (uint8_t *)malloc(Page::Size);
       if (Page == nullptr) {
-        fmt::print("Failed to call aligned_alloc.\n");
+        fmt::print("Failed to allocate memory.\n");
         return nullptr;
       }
 


### PR DESCRIPTION
I was profiling `wtf` and found a behavior that I wasn't aware of. Basically, every calls we make to `aligned_alloc` allocates 8kish instead of 4kish. For whatever reason, I made an assumption that it would use a special allocator; it isn't a special allocator it just wraps a call to `malloc` with that math: `v5 = malloc(Alignment - 1 + Size + 8);`. In our case, both `Alignment` & `Size` are `0x1000`.

I switched the calls to `aligned_alloc` to `VirtualAlloc` / `mmap` to match the behavior that I wanted in the first place. We also don't need page aligned chunks in the `Ram_t` object, so I turned this one into a `malloc` call.

Here is a screenshot before the fix:
<img width="506" alt="before" src="https://user-images.githubusercontent.com/1476421/208320485-2f493f50-f364-471d-97db-d058e87f3f14.png">

And here is a screenshot after the fix:
<img width="515" alt="after" src="https://user-images.githubusercontent.com/1476421/208320498-e6025750-b0d9-4358-85a6-c1b17d14f1b1.png">
