### PR TITLE
add "ioctl" target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@
 *.out
 *.app
 
-src/wtf/fuzzer_*
+.vs
 src/build/
 src/build_msvc/
+src/out
 targets/

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.app
 
 .vs
+src/wtf/fuzzer_*
 src/build/
 src/build_msvc/
 src/out

--- a/src/hevd_client/hevd_client.cc
+++ b/src/hevd_client/hevd_client.cc
@@ -4,7 +4,7 @@
 #include <array>
 #include <cstdio>
 
-int main() {
+int main(int argc, char *argv[]) {
   HANDLE H =
       CreateFileA(R"(\\.\GLOBALROOT\Device\HackSysExtremeVulnerableDriver)",
                   GENERIC_ALL, 0, nullptr, OPEN_EXISTING, 0, nullptr);
@@ -13,14 +13,73 @@ int main() {
     return EXIT_FAILURE;
   }
 
-  std::array<uint8_t, 1024> Buffer;
+  std::array<uint8_t, 1024> BufferBacking = {};
   if (getenv("BREAK") != nullptr) {
     __debugbreak();
   }
 
   DWORD Returned = 0;
-  DeviceIoControl(H, 0xdeadbeef, Buffer.data(), Buffer.size(), Buffer.data(),
-                  Buffer.size(), &Returned, nullptr);
+  DWORD IoctlCode = 0xdeadbeef;
+  PVOID Buffer = BufferBacking.data();
+  size_t BufferSize = BufferBacking.size();
+  if (argc > 1) {
+    FILE *File = fopen(argv[1], "rb");
+    if (File == nullptr) {
+      printf("fopen failed, bailing.\n");
+      return EXIT_FAILURE;
+    }
+
+    if (fseek(File, 0, SEEK_END) != 0) {
+      printf("fseek to the end failed, bailing.\n");
+      fclose(File);
+      return EXIT_FAILURE;
+    }
+
+    const long R = ftell(File);
+    if (R == -1 || R < 0) {
+      printf("ftell failed, bailing.\n");
+      fclose(File);
+      return EXIT_FAILURE;
+    }
+
+    const auto TotalSize = uint32_t(R);
+    if (fseek(File, 0, SEEK_SET) != 0) {
+      printf("fseek back to the beginning failed, bailing.\n");
+      fclose(File);
+      return EXIT_FAILURE;
+    }
+
+    if (fread(&IoctlCode, sizeof(IoctlCode), 1, File) != 1) {
+      printf("fread failed when reading ioctl code, bailing.\n");
+      fclose(File);
+      return EXIT_FAILURE;
+    }
+
+    BufferSize = TotalSize - sizeof(uint32_t);
+    Buffer = calloc(BufferSize, 1);
+    if (Buffer == nullptr) {
+      printf("calloc failed, bailing.\n");
+      fclose(File);
+      return EXIT_FAILURE;
+    }
+
+    if (fread(Buffer, BufferSize, 1, File) != 1) {
+      printf("fread failed when reading buffer, bailing.\n");
+      fclose(File);
+      free(Buffer);
+      return EXIT_FAILURE;
+    }
+
+    fclose(File);
+  }
+
+  DeviceIoControl(H, IoctlCode, Buffer, BufferSize, Buffer, BufferSize,
+                  &Returned, nullptr);
   CloseHandle(H);
+
+  if (Buffer != BufferBacking.data()) {
+    free(Buffer);
+  }
+
   return EXIT_SUCCESS;
 }

--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -145,7 +145,8 @@ bool Backend_t::SimulateReturnFromFunction(const uint64_t Return) {
   return true;
 }
 
-bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t StdcallArgsCount) {
+bool Backend_t::SimulateReturnFrom32bitFunction(
+    const uint32_t Return, const uint32_t StdcallArgsCount) {
   //
   // Set return value.
   //
@@ -164,7 +165,7 @@ bool Backend_t::SimulateReturnFrom32bitFunction(const uint32_t Return, const uin
   return true;
 }
 
-uint64_t Backend_t::GetArg(const uint64_t Idx) {
+uint64_t Backend_t::GetArg(const uint64_t Idx, Gva_t &Address) {
   switch (Idx) {
   case 0:
     return Rcx();
@@ -175,13 +176,25 @@ uint64_t Backend_t::GetArg(const uint64_t Idx) {
   case 3:
     return R9();
   default: {
-    const Gva_t ArgPtr = Gva_t(Rsp() + (8 + (Idx * 8)));
-    return VirtRead8(ArgPtr);
+    Address = Gva_t(Rsp() + (8 + (Idx * 8)));
+    return VirtRead8(Address);
   }
   }
 }
 
-Gva_t Backend_t::GetArgGva(const uint64_t Idx) { return Gva_t(GetArg(Idx)); }
+uint64_t Backend_t::GetArg(const uint64_t Idx) {
+  Gva_t Dummy;
+  return GetArg(Idx, Dummy);
+}
+
+Gva_t Backend_t::GetArgGva(const uint64_t Idx, Gva_t &Address) {
+  return Gva_t(GetArg(Idx, Address));
+}
+
+Gva_t Backend_t::GetArgGva(const uint64_t Idx) {
+  Gva_t Dummy;
+  return Gva_t(GetArg(Idx, Dummy));
+}
 
 bool Backend_t::SaveCrash(const Gva_t ExceptionAddress,
                           const uint32_t ExceptionCode) {

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -322,17 +322,17 @@ public:
   // Read a uint64_t.
   //
 
-  uint64_t VirtRead8(const Gva_t Gva) const;
-  Gva_t VirtReadGva(const Gva_t Gva) const;
-  Gpa_t VirtReadGpa(const Gva_t Gva) const;
+  [[nodiscard]] uint64_t VirtRead8(const Gva_t Gva) const;
+  [[nodiscard]] Gva_t VirtReadGva(const Gva_t Gva) const;
+  [[nodiscard]] Gpa_t VirtReadGpa(const Gva_t Gva) const;
 
   //
   // Read a basic string.
   //
 
   template <typename _Ty>
-  std::basic_string<_Ty> VirtReadBasicString(const Gva_t StringGva,
-                                             const uint64_t MaxLength) const {
+  [[nodiscard]] std::basic_string<_Ty>
+  VirtReadBasicString(const Gva_t StringGva, const uint64_t MaxLength) const {
     using BasicString_t = std::basic_string<_Ty>;
     using ValueType_t = typename BasicString_t::value_type;
 
@@ -432,15 +432,15 @@ public:
   // Read a basic_string<char>.
   //
 
-  std::string VirtReadString(const Gva_t Gva,
-                             const uint64_t MaxLength = 256) const;
+  [[nodiscard]] std::string
+  VirtReadString(const Gva_t Gva, const uint64_t MaxLength = 256) const;
 
   //
   // Read a basic_string<char16_t> (used to read wchar_t* in Windows guests).
   //
 
-  std::u16string VirtReadWideString(const Gva_t Gva,
-                                    const uint64_t MaxLength = 256) const;
+  [[nodiscard]] std::u16string
+  VirtReadWideString(const Gva_t Gva, const uint64_t MaxLength = 256) const;
 
   //
   // Write in virtual memory. Optionally track dirtiness on the memory range.
@@ -489,80 +489,90 @@ public:
   // calling convention.
   //
 
-  uint64_t GetArg(const uint64_t Idx, Gva_t &Address);
-  uint64_t GetArg(const uint64_t Idx);
-  Gva_t GetArgGva(const uint64_t Idx, Gva_t &Address);
-  Gva_t GetArgGva(const uint64_t Idx);
+  [[nodiscard]] uint64_t GetArg(const uint64_t Idx);
+  [[nodiscard]] Gva_t GetArgGva(const uint64_t Idx);
+
+  //
+  // Utility function to get the address of a function argument. Oftentimes, you
+  // need to overwrite an argument that isn't stored in registers which means
+  // you need to calculate yourself where it is stored on the stack. This
+  // function gives you its address.
+  //
+
+  [[nodiscard]] Gva_t GetArgAddress(const uint64_t Idx);
+  [[nodiscard]] std::pair<uint64_t, Gva_t> GetArgAndAddress(const uint64_t Idx);
+  [[nodiscard]] std::pair<Gva_t, Gva_t> GetArgAndAddressGva(const uint64_t Idx);
+
 
   //
   // Shortcuts to grab / set some registers.
   //
 
-  uint64_t Rsp();
+  [[nodiscard]] uint64_t Rsp();
   void Rsp(const uint64_t Value);
   void Rsp(const Gva_t Value);
 
-  uint64_t Rbp();
+  [[nodiscard]] uint64_t Rbp();
   void Rbp(const uint64_t Value);
   void Rbp(const Gva_t Value);
 
-  uint64_t Rip();
+  [[nodiscard]] uint64_t Rip();
   void Rip(const uint64_t Value);
   void Rip(const Gva_t Value);
 
-  uint64_t Rax();
+  [[nodiscard]] uint64_t Rax();
   void Rax(const uint64_t Value);
   void Rax(const Gva_t Value);
 
-  uint64_t Rbx();
+  [[nodiscard]] uint64_t Rbx();
   void Rbx(const uint64_t Value);
   void Rbx(const Gva_t Value);
 
-  uint64_t Rcx();
+  [[nodiscard]] uint64_t Rcx();
   void Rcx(const uint64_t Value);
   void Rcx(const Gva_t Value);
 
-  uint64_t Rdx();
+  [[nodiscard]] uint64_t Rdx();
   void Rdx(const uint64_t Value);
   void Rdx(const Gva_t Value);
 
-  uint64_t Rsi();
+  [[nodiscard]] uint64_t Rsi();
   void Rsi(const uint64_t Value);
   void Rsi(const Gva_t Value);
 
-  uint64_t Rdi();
+  [[nodiscard]] uint64_t Rdi();
   void Rdi(const uint64_t Value);
   void Rdi(const Gva_t Value);
 
-  uint64_t R8();
+  [[nodiscard]] uint64_t R8();
   void R8(const uint64_t Value);
   void R8(const Gva_t Value);
 
-  uint64_t R9();
+  [[nodiscard]] uint64_t R9();
   void R9(const uint64_t Value);
   void R9(const Gva_t Value);
 
-  uint64_t R10();
+  [[nodiscard]] uint64_t R10();
   void R10(const uint64_t Value);
   void R10(const Gva_t Value);
 
-  uint64_t R11();
+  [[nodiscard]] uint64_t R11();
   void R11(const uint64_t Value);
   void R11(const Gva_t Value);
 
-  uint64_t R12();
+  [[nodiscard]] uint64_t R12();
   void R12(const uint64_t Value);
   void R12(const Gva_t Value);
 
-  uint64_t R13();
+  [[nodiscard]] uint64_t R13();
   void R13(const uint64_t Value);
   void R13(const Gva_t Value);
 
-  uint64_t R14();
+  [[nodiscard]] uint64_t R14();
   void R14(const uint64_t Value);
   void R14(const Gva_t Value);
 
-  uint64_t R15();
+  [[nodiscard]] uint64_t R15();
   void R15(const uint64_t Value);
   void R15(const Gva_t Value);
 

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -481,14 +481,17 @@ public:
   //
 
   bool SimulateReturnFromFunction(const uint64_t Return);
-  bool SimulateReturnFrom32bitFunction(const uint32_t Return, const uint32_t StdcallArgsCount = 0);
+  bool SimulateReturnFrom32bitFunction(const uint32_t Return,
+                                       const uint32_t StdcallArgsCount = 0);
 
   //
   // Utility function that grabs function arguments according to the Windows x64
   // calling convention.
   //
 
+  uint64_t GetArg(const uint64_t Idx, Gva_t &Address);
   uint64_t GetArg(const uint64_t Idx);
+  Gva_t GetArgGva(const uint64_t Idx, Gva_t &Address);
   Gva_t GetArgGva(const uint64_t Idx);
 
   //

--- a/src/wtf/fuzzer_hevd.cc
+++ b/src/wtf/fuzzer_hevd.cc
@@ -49,8 +49,7 @@ bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
   }
 
   g_Backend->R9(IoctlBufferSize);
-  Gva_t OutBufferSizePtr;
-  g_Backend->GetArgGva(5, OutBufferSizePtr);
+  const auto &OutBufferSizePtr = g_Backend->GetArgAddress(5);
   if (!g_Backend->VirtWriteStructDirty(OutBufferSizePtr, &IoctlBufferSize)) {
     DebugPrint("VirtWriteStructDirty failed\n");
     return false;

--- a/src/wtf/fuzzer_hevd.cc
+++ b/src/wtf/fuzzer_hevd.cc
@@ -49,8 +49,8 @@ bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
   }
 
   g_Backend->R9(IoctlBufferSize);
-  const Gva_t Rsp = Gva_t(g_Backend->Rsp());
-  const Gva_t OutBufferSizePtr = Rsp + Gva_t(5 * sizeof(uint64_t));
+  Gva_t OutBufferSizePtr;
+  g_Backend->GetArgGva(5, OutBufferSizePtr);
   if (!g_Backend->VirtWriteStructDirty(OutBufferSizePtr, &IoctlBufferSize)) {
     DebugPrint("VirtWriteStructDirty failed\n");
     return false;

--- a/src/wtf/fuzzer_ioctl.cc
+++ b/src/wtf/fuzzer_ioctl.cc
@@ -1,0 +1,187 @@
+// 1ndahous3 - March 4 2023
+#include "backend.h"
+#include "targets.h"
+#include <fmt/format.h>
+
+// 1. The target works with the state captured at the breakpoint at "ntdll!NtDeviceIoControlFile()".
+// 2. It's better to capture a state with the maximum possible InputBufferLength.
+// 3. For "MutateIoctl = true" tescases are manually created buffers: Ioctl (4 bytes) + InputBuffer ("InputBufferLength" bytes).
+
+namespace Ioctl {
+
+constexpr bool DebugLoggingOn = false;
+constexpr bool MutateIoctl = true;
+
+constexpr uint32_t IoctlSizeIfPresent = MutateIoctl ? sizeof(uint32_t) : 0;
+
+template <typename... Args_t>
+void Print(const char *Format, const Args_t &...args) {
+  fmt::print("Ioctl: ");
+  fmt::print(fmt::runtime(Format), args...);
+}
+
+template <typename... Args_t>
+void DebugPrint(const char *Format, const Args_t &...args) {
+  if constexpr (DebugLoggingOn) {
+    fmt::print("Ioctl: ");
+    fmt::print(fmt::runtime(Format), args...);
+  }
+}
+
+bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
+
+  if constexpr (MutateIoctl) {
+    if (BufferSize < sizeof(uint32_t)) {
+      Print("The testcase buffer is too small: {} bytes\n", BufferSize);
+      return false;
+    }
+  } else {
+    if (BufferSize == 0) {
+      Print("The testcase buffer is empty");
+      return false;
+    }
+  }
+
+  const uint8_t *IoctlBuffer = Buffer + IoctlSizeIfPresent;
+  uint32_t IoctlBufferSize = BufferSize - IoctlSizeIfPresent;
+
+  // ntdll!NtDeviceIoControlFile()
+  // Ioctl:              @rsp + 0x30
+  // InputBuffer:        @rsp + 0x38
+  // InputBufferLength:  @rsp + 0x40
+
+  const Gva_t Stack = Gva_t(g_Backend->Rsp());
+
+  const Gva_t InputBufferLengthPtr = Stack + Gva_t(0x40);
+  uint32_t CurrentIoctlBufferSize = g_Backend->VirtRead4(InputBufferLengthPtr);
+
+  if (IoctlBufferSize > CurrentIoctlBufferSize) {
+    DebugPrint("The testcase buffer is too large: {} ({:#x}) bytes, "
+               "maximum for the state: {} ({:#x}) bytes \n",
+               BufferSize, BufferSize,
+               CurrentIoctlBufferSize + IoctlSizeIfPresent,
+               CurrentIoctlBufferSize + IoctlSizeIfPresent);
+    return true;
+  }
+
+  if (!g_Backend->VirtWriteStructDirty(InputBufferLengthPtr,
+                                       &IoctlBufferSize)) {
+    Print("VirtWriteDirty (InputBufferLength) failed\n");
+    return false;
+  }
+
+   if constexpr (MutateIoctl) {
+
+    const uint32_t Ioctl = *(uint32_t *)Buffer;
+    const Gva_t IoctlPtr = Stack + Gva_t(0x30);
+
+    if (!g_Backend->VirtWriteStructDirty(IoctlPtr, &Ioctl)) {
+      Print("VirtWriteDirty (Ioctl) failed\n");
+      return false;
+    }
+  }
+
+  const Gva_t InputBufferPtr = g_Backend->VirtReadGva(Stack + Gva_t(0x38));
+  if (!g_Backend->VirtWriteDirty(InputBufferPtr, IoctlBuffer, IoctlBufferSize)) {
+    Print("VirtWriteDirty (InputBuffer) failed\n");
+    return false;
+  }
+
+  return true;
+}
+
+bool Init(const Options_t &Opts, const CpuState_t &) {
+
+  //
+  // Stop the test-case once we return back from the call [NtDeviceIoControlFile]
+  //
+
+  const Gva_t Rip = Gva_t(g_Backend->Rip());
+  const Gva_t AfterCall = Rip + Gva_t(0x14);
+  if (!g_Backend->SetBreakpoint(AfterCall, [](Backend_t *Backend) {
+        DebugPrint("Back from kernel!\n");
+        Backend->Stop(Ok_t());
+      })) {
+    Print("Failed to SetBreakpoint AfterCall\n");
+    return false;
+  }
+
+  //
+  // NOP the calls to DbgPrintEx.
+  //
+
+  if (!g_Backend->SetBreakpoint("nt!DbgPrintEx", [](Backend_t *Backend) {
+        const Gva_t FormatPtr = Backend->GetArgGva(2);
+        const std::string &Format = Backend->VirtReadString(FormatPtr);
+        DebugPrint("DbgPrintEx: {}", Format);
+        Backend->SimulateReturnFromFunction(0);
+      })) {
+    Print("Failed to SetBreakpoint DbgPrintEx\n");
+    return false;
+  }
+
+  //
+  // Make ExGenRandom deterministic.
+  //
+  // kd> ub fffff805`3b8287c4 l1
+  // nt!ExGenRandom+0xe0:
+  // fffff805`3b8287c0 480fc7f2        rdrand  rdx
+  const Gva_t ExGenRandom = Gva_t(g_Dbg.GetSymbol("nt!ExGenRandom") + 0xf3);
+  if (g_Backend->VirtRead4(ExGenRandom) != 0xb8f2c70f) {
+    Print("It seems that nt!ExGenRandom's code has changed, update the "
+          "offset!\n");
+    return false;
+  }
+
+  if (!g_Backend->SetBreakpoint(ExGenRandom, [](Backend_t *Backend) {
+        DebugPrint("Hit ExGenRandom!\n");
+        Backend->Rdx(Backend->Rdrand());
+      })) {
+    Print("Failed to SetBreakpoint ExGenRandom\n");
+    return false;
+  }
+
+  //
+  // Catch bugchecks.
+  //
+
+  if (!g_Backend->SetBreakpoint("nt!KeBugCheck2", [](Backend_t *Backend) {
+        const uint64_t BCode = Backend->GetArg(0);
+        const uint64_t B0 = Backend->GetArg(1);
+        const uint64_t B1 = Backend->GetArg(2);
+        const uint64_t B2 = Backend->GetArg(3);
+        const uint64_t B3 = Backend->GetArg(4);
+        const uint64_t B4 = Backend->GetArg(5);
+        const std::string Filename =
+            fmt::format("crash-{:#x}-{:#x}-{:#x}-{:#x}-{:#x}-{:#x}", BCode, B0,
+                        B1, B2, B3, B4);
+        DebugPrint("KeBugCheck2: {}\n", Filename);
+        Backend->Stop(Crash_t(Filename));
+      })) {
+    Print("Failed to SetBreakpoint KeBugCheck2\n");
+    return false;
+  }
+
+  //
+  // Catch context-switches.
+  //
+
+  if (!g_Backend->SetBreakpoint("nt!SwapContext", [](Backend_t *Backend) {
+        DebugPrint("nt!SwapContext\n");
+        Backend->Stop(Cr3Change_t());
+      })) {
+    Print("Failed to SetBreakpoint SwapContext\n");
+    return false;
+  }
+
+
+  return true;
+}
+
+//
+// Register the target.
+//
+
+Target_t Ioctl("ioctl", Init, InsertTestcase);
+
+} // namespace Ioctl

--- a/src/wtf/fuzzer_ioctl.cc
+++ b/src/wtf/fuzzer_ioctl.cc
@@ -3,106 +3,190 @@
 #include "targets.h"
 #include <fmt/format.h>
 
-// 1. The target works with the state captured at the breakpoint at "ntdll!NtDeviceIoControlFile()".
-// 2. It's better to capture a state with the maximum possible InputBufferLength.
-// 3. For "MutateIoctl = true" tescases are manually created buffers: Ioctl (4 bytes) + InputBuffer ("InputBufferLength" bytes).
-
 namespace Ioctl {
 
 constexpr bool DebugLoggingOn = false;
 constexpr bool MutateIoctl = true;
 
-constexpr uint32_t IoctlSizeIfPresent = MutateIoctl ? sizeof(uint32_t) : 0;
-
-template <typename... Args_t>
-void Print(const char *Format, const Args_t &...args) {
-  fmt::print("Ioctl: ");
-  fmt::print(fmt::runtime(Format), args...);
-}
+#define Print(Fmt, ...) fmt::print("ioctl: " Fmt, __VA_ARGS__)
 
 template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {
   if constexpr (DebugLoggingOn) {
-    fmt::print("Ioctl: ");
+    fmt::print("ioctl: ");
     fmt::print(fmt::runtime(Format), args...);
   }
 }
 
+std::unique_ptr<uint8_t[]> g_LastBuffer;
+size_t g_LastBufferSize = 0;
+
 bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
+
+  //
+  // If we have a testcase still alive, it means we haven't hit the return
+  // breakpoint which is suspicious.
+  //
+
+  static bool FirstTime = true;
+  if (!FirstTime) {
+    if (!g_LastBuffer || g_LastBufferSize == 0) {
+      Print("The testcase hasn't been reset; something is wrong\n");
+      std::abort();
+    }
+  } else {
+    FirstTime = false;
+  }
+
+  //
+  // If we are mutating the IoControlCode, we expect at least 4 bytes.
+  //
 
   if constexpr (MutateIoctl) {
     if (BufferSize < sizeof(uint32_t)) {
       Print("The testcase buffer is too small: {} bytes\n", BufferSize);
       return false;
     }
-  } else {
-    if (BufferSize == 0) {
-      Print("The testcase buffer is empty");
-      return false;
-    }
   }
 
-  const uint8_t *IoctlBuffer = Buffer + IoctlSizeIfPresent;
-  uint32_t IoctlBufferSize = BufferSize - IoctlSizeIfPresent;
+  //
+  // Copy the testcase; we'll inject it later if we hit NtDeviceIoControlFile.
+  //
 
-  // ntdll!NtDeviceIoControlFile()
-  // Ioctl:              @rsp + 0x30
-  // InputBuffer:        @rsp + 0x38
-  // InputBufferLength:  @rsp + 0x40
-
-  const Gva_t Stack = Gva_t(g_Backend->Rsp());
-
-  const Gva_t InputBufferLengthPtr = Stack + Gva_t(0x40);
-  uint32_t CurrentIoctlBufferSize = g_Backend->VirtRead4(InputBufferLengthPtr);
-
-  if (IoctlBufferSize > CurrentIoctlBufferSize) {
-    DebugPrint("The testcase buffer is too large: {} ({:#x}) bytes, "
-               "maximum for the state: {} ({:#x}) bytes \n",
-               BufferSize, BufferSize,
-               CurrentIoctlBufferSize + IoctlSizeIfPresent,
-               CurrentIoctlBufferSize + IoctlSizeIfPresent);
-    return true;
-  }
-
-  if (!g_Backend->VirtWriteStructDirty(InputBufferLengthPtr,
-                                       &IoctlBufferSize)) {
-    Print("VirtWriteDirty (InputBufferLength) failed\n");
-    return false;
-  }
-
-   if constexpr (MutateIoctl) {
-
-    const uint32_t Ioctl = *(uint32_t *)Buffer;
-    const Gva_t IoctlPtr = Stack + Gva_t(0x30);
-
-    if (!g_Backend->VirtWriteStructDirty(IoctlPtr, &Ioctl)) {
-      Print("VirtWriteDirty (Ioctl) failed\n");
-      return false;
-    }
-  }
-
-  const Gva_t InputBufferPtr = g_Backend->VirtReadGva(Stack + Gva_t(0x38));
-  if (!g_Backend->VirtWriteDirty(InputBufferPtr, IoctlBuffer, IoctlBufferSize)) {
-    Print("VirtWriteDirty (InputBuffer) failed\n");
-    return false;
-  }
-
+  g_LastBufferSize = BufferSize;
+  g_LastBuffer = std::make_unique<uint8_t[]>(BufferSize);
+  std::memcpy(g_LastBuffer.get(), Buffer, BufferSize);
   return true;
 }
 
 bool Init(const Options_t &Opts, const CpuState_t &) {
 
   //
-  // Stop the test-case once we return back from the call [NtDeviceIoControlFile]
+  // Break on nt!NtDeviceIoControlFile. This is at that moment that we'll insert
+  // the testcase.
   //
 
-  const Gva_t Rip = Gva_t(g_Backend->Rip());
-  const Gva_t AfterCall = Rip + Gva_t(0x14);
-  if (!g_Backend->SetBreakpoint(AfterCall, [](Backend_t *Backend) {
-        DebugPrint("Back from kernel!\n");
-        Backend->Stop(Ok_t());
-      })) {
-    Print("Failed to SetBreakpoint AfterCall\n");
+  if (!g_Backend->SetBreakpoint(
+          "nt!NtDeviceIoControlFile", [](Backend_t *Backend) {
+            //
+            // The first time we hit this breakpoint, we
+            // grab the return address and we set a
+            // breakpoint there to finish the testcase.
+            //
+
+            static bool SetExitBreakpoint = false;
+            if (!SetExitBreakpoint) {
+              const auto ReturnAddress =
+                  Backend->VirtReadGva(Gva_t(Backend->Rsp()));
+              if (!Backend->SetBreakpoint(
+                      ReturnAddress, [](Backend_t *Backend) {
+                        //
+                        // Ok we're done!
+                        //
+
+                        DebugPrint("Hit return breakpoint!\n");
+                        Backend->Stop(Ok_t());
+                        g_LastBuffer = nullptr;
+                        g_LastBufferSize = 0;
+                      })) {
+                Print("Failed to set breakpoint on return\n");
+                std::abort();
+              }
+
+              SetExitBreakpoint = true;
+            }
+
+            //
+            // If we don't have a testcase, then things are in a broken state,
+            // so abort.
+            //
+
+            if (!g_LastBuffer || g_LastBufferSize == 0) {
+              Print("Hit NtDeviceIoControlFile w/o a testcase..?\n");
+              std::abort();
+            }
+
+            //
+            // If we're mutating the IoControlCode, then the first 4 bytes are
+            // that.
+            //
+
+            constexpr uint32_t IoctlSizeIfPresent =
+                MutateIoctl ? sizeof(uint32_t) : 0;
+
+            //
+            // We can only insert testcases that are smaller or equal to the
+            // current size; otherwise we'll corrupt memory. To work around
+            // this, we truncate it if it's larger.
+            //
+
+            //
+            // __kernel_entry NTSTATUS
+            // NtDeviceIoControlFile(
+            //  [in]  HANDLE           FileHandle,
+            //  [in]  HANDLE           Event,
+            //  [in]  PIO_APC_ROUTINE  ApcRoutine,
+            //  [in]  PVOID            ApcContext,
+            //  [out] PIO_STATUS_BLOCK IoStatusBlock,
+            //  [in]  ULONG            IoControlCode,
+            //  [in]  PVOID            InputBuffer,
+            //  [in]  ULONG            InputBufferLength,
+            //  [out] PVOID            OutputBuffer,
+            //  [in]  ULONG            OutputBufferLength
+            // );
+            //
+
+            const uint32_t TotalInputBufferSize =
+                g_LastBufferSize - IoctlSizeIfPresent;
+            const auto MutatedIoControlCodePtr = (uint32_t *)g_LastBuffer.get();
+            const uint8_t *MutatedInputBufferPtr =
+                g_LastBuffer.get() + IoctlSizeIfPresent;
+            Gva_t InputBufferSizePtr;
+            const auto InputBufferSize =
+                uint32_t(Backend->GetArg(7, InputBufferSizePtr));
+            const uint32_t MutatedInputBufferSize =
+                std::min(TotalInputBufferSize, InputBufferSize);
+
+            //
+            // Fix up InputBufferLength.
+            //
+
+            if (!Backend->VirtWriteStructDirty(InputBufferSizePtr,
+                                               &MutatedInputBufferSize)) {
+              Print("Failed to fix up the InputBufferSize\n");
+              std::abort();
+            }
+
+            //
+            // Insert the testcase in the InputBuffer.
+            // XXX: Ideally, we'd push up the testcase to the
+            // boundary of the buffer to have a better chance to
+            // catch OOBs and update the InputBuffer pointer.
+            //
+
+            if (!Backend->VirtWriteDirty(Backend->GetArgGva(8),
+                                         MutatedInputBufferPtr,
+                                         MutatedInputBufferSize)) {
+              Print("Failed to insert the testcase\n");
+              std::abort();
+            }
+
+            //
+            // Are we mutating IoControlCode as well?
+            //
+
+            if constexpr (MutateIoctl) {
+              const auto MutatedIoControlCode = *MutatedIoControlCodePtr;
+              Gva_t IoControlCodePtr;
+              Backend->GetArgGva(5, IoControlCodePtr);
+              if (!Backend->VirtWriteStructDirty(IoControlCodePtr,
+                                                 &MutatedIoControlCode)) {
+                Print("Failed to VirtWriteStructDirty (Ioctl) failed\n");
+                std::abort();
+              }
+            }
+          })) {
+    Print("Failed to SetBreakpoint NtDeviceIoControlFile\n");
     return false;
   }
 
@@ -126,8 +210,8 @@ bool Init(const Options_t &Opts, const CpuState_t &) {
   // kd> ub fffff805`3b8287c4 l1
   // nt!ExGenRandom+0xe0:
   // fffff805`3b8287c0 480fc7f2        rdrand  rdx
-  const Gva_t ExGenRandom = Gva_t(g_Dbg.GetSymbol("nt!ExGenRandom") + 0xf3);
-  if (g_Backend->VirtRead4(ExGenRandom) != 0xb8f2c70f) {
+  const Gva_t ExGenRandom = Gva_t(g_Dbg.GetSymbol("nt!ExGenRandom") + 0xe0 + 4);
+  if (g_Backend->VirtRead4(ExGenRandom - Gva_t(4)) != 0xf2c70f48) {
     Print("It seems that nt!ExGenRandom's code has changed, update the "
           "offset!\n");
     return false;
@@ -173,7 +257,6 @@ bool Init(const Options_t &Opts, const CpuState_t &) {
     Print("Failed to SetBreakpoint SwapContext\n");
     return false;
   }
-
 
   return true;
 }

--- a/src/wtf/fuzzer_ioctl.cc
+++ b/src/wtf/fuzzer_ioctl.cc
@@ -30,8 +30,7 @@ bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
 
   if constexpr (MutateIoctl) {
     if (BufferSize < sizeof(uint32_t)) {
-      fmt::print("The testcase buffer is too small: {} bytes\n", BufferSize);
-      return false;
+      return true;
     }
   }
 
@@ -154,6 +153,7 @@ bool Init(const Options_t &Opts, const CpuState_t &) {
 
             static bool SetExitBreakpoint = false;
             if (!SetExitBreakpoint) {
+              SetExitBreakpoint = true;
               const auto ReturnAddress =
                   Backend->VirtReadGva(Gva_t(Backend->Rsp()));
               if (!Backend->SetBreakpoint(

--- a/src/wtf/fuzzer_ioctl.cc
+++ b/src/wtf/fuzzer_ioctl.cc
@@ -74,20 +74,19 @@ bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
   // inject it all, or we need to truncate it.
   //
 
-  Gva_t InputBufferSizePtr;
-  const auto InputBufferSize =
-      uint32_t(g_Backend->GetArg(7, InputBufferSizePtr));
+  const auto &[InputBufferSize, InputBufferSizePtr] =
+      g_Backend->GetArgAndAddress(7);
   const uint32_t MutatedInputBufferSize =
-      std::min(TotalInputBufferSize, InputBufferSize);
+      std::min(TotalInputBufferSize, uint32_t(InputBufferSize));
 
   //
   // Calculate the new InputBuffer address by pushing the mutated buffer as
   // close as possible from its end.
   //
 
-  Gva_t InputBufferPtr;
-  const auto NewInputBuffer = Gva_t(g_Backend->GetArg(6, InputBufferPtr) +
-                                    InputBufferSize - MutatedInputBufferSize);
+  const auto &[InputBuffer, InputBufferPtr] = g_Backend->GetArgAndAddress(6);
+  const auto NewInputBuffer =
+      Gva_t(InputBuffer + InputBufferSize - MutatedInputBufferSize);
 
   //
   // Fix up InputBufferLength.
@@ -124,8 +123,7 @@ bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
 
   if constexpr (MutateIoctl) {
     const auto MutatedIoControlCode = *MutatedIoControlCodePtr;
-    Gva_t IoControlCodePtr;
-    g_Backend->GetArgGva(5, IoControlCodePtr);
+    const auto &IoControlCodePtr = g_Backend->GetArgAddress(5);
     if (!g_Backend->VirtWriteStructDirty(IoControlCodePtr,
                                          &MutatedIoControlCode)) {
       fmt::print("Failed to VirtWriteStructDirty (Ioctl) failed\n");

--- a/src/wtf/fuzzer_ioctl.cc
+++ b/src/wtf/fuzzer_ioctl.cc
@@ -11,8 +11,8 @@
 
 namespace Ioctl {
 
-constexpr bool DebugLoggingOn = true;
-constexpr bool MutateIoctl = false;
+constexpr bool DebugLoggingOn = false;
+constexpr bool MutateIoctl = true;
 
 template <typename... Args_t>
 void DebugPrint(const char *Format, const Args_t &...args) {


### PR DESCRIPTION
Universal code for fuzzing any driver from the state captured on `ntdll!NtDeviceIoControlFile()`.

There are 2 modes (switchable at compile time via `MutateIoctl` flag):
1. Mutate only the buffer - IOCTL from the state does not change.
2. Mutate buffer and IOCTL - the IOCTL is captured from the first 4 bytes of the input buffer).