### PR TITLE
Add explanation message if WHvCreatePartition fails

### DIFF
--- a/src/wtf/whv_backend.cc
+++ b/src/wtf/whv_backend.cc
@@ -112,7 +112,7 @@ bool WhvBackend_t::Initialize(const Options_t &Opts,
 
   HRESULT Hr = WHvCreatePartition(&Partition_);
   if (FAILED(Hr)) {
-    fmt::print("Failed WHvCreatePartition\n");
+    fmt::print("Failed WHvCreatePartition (Windows Hypervisor Platform enabled?)\n");
     return false;
   }
 


### PR DESCRIPTION
WHvCreatePartition will fail even if Hyper-V is enabled but hypervisor platform is not (which is hidden in Windows Server 2019) and it took me a bit to figure out, so I thought I'd add a message for anyone else who runs into the issue.