### PR TITLE
Added experimental Compcov/LAF support for the Bochs backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,8 @@ src/wtf/fuzzer_*
 src/build/
 src/build_msvc/
 src/out
+src/.cache
 targets/
+__pycache__/
+
+compile_commands.*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The best way to try the features out is to work with the [fuzzer_hevd](src/wtf/f
 
 ### Starting a server node
 
-The server is basically the brain and keeps track of all the state: the  aggregated code-coverage, the corpus, it generates and distributes the test-cases to client.
+The server is basically the brain and keeps track of all the state: the aggregated code-coverage, the corpus, it generates and distributes the test-cases to client.
 
 This is how you might choose to launch a server node:
 
@@ -284,6 +284,7 @@ In this section I briefly mention various differences between the execution back
 
 ### bochscpu
 - ✅ Full system code-coverage (edge coverage available via `--edges`),
+- ✅ LAF/Compcov assisted coverage collection (available via `--compcov` and `--laf` options),
 - ✅ Demand-paging,
 - ✅ Timeout is the number of instructions which is very precise,
 - ✅ Full execution traces are supported,

--- a/scripts/alternative.yaml
+++ b/scripts/alternative.yaml
@@ -1,0 +1,59 @@
+title: wtf-laf-config
+seed: 1337
+target-dir: .
+
+master:
+  runs: 999000000
+  max_len: 120000
+  name: rizin
+  inputs: inputs
+  outputs: outputs
+
+nodes:
+  bochs-laf-compcov:
+    backend: bochscpu
+    edges: 1
+    compcov: 1
+    laf: user
+    laf-allowed-ranges: 0x7FF7FE680000-0x7FF7FF405000
+    name: rizin
+    limit: 900000
+
+  bochs-laf:
+    backend: bochscpu
+    edges: 1
+    compcov: 0
+    laf: user
+    laf-allowed-ranges: 0x7FF7FE680000-0x7FF7FF405000
+    name: rizin
+    limit: 900000
+
+  kvm-none-0:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-1:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-2:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-3:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-4:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-5:
+    backend: kvm
+    name: rizin
+    limit: 2

--- a/scripts/analyze-experiments.py
+++ b/scripts/analyze-experiments.py
@@ -1,0 +1,183 @@
+import argparse as ap
+import pathlib
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+import yaml
+
+
+def load_single_result(result_file: pathlib.Path) -> pd.DataFrame:
+    dataframe = pd.read_json(result_file)["stats"]
+    relative_timestamps = [entry["relative_timestamp"] for entry in dataframe]
+    coverage = [entry["coverage"] for entry in dataframe]
+    crashes = [entry["crashes"] for entry in dataframe]
+    execs_sec = [entry["execs_sec"] for entry in dataframe]
+    corpus_size = [entry["corpus_size"] for entry in dataframe]
+    dataframe = pd.DataFrame(
+        {
+            f"relative_timestamp-{result_file.stem}": relative_timestamps,
+            f"coverage-{result_file.stem}": coverage,
+            f"crashes-{result_file.stem}": crashes,
+            f"execs_sec-{result_file.stem}": execs_sec,
+            f"corpus_size-{result_file.stem}": corpus_size,
+        }
+    )
+    return dataframe
+
+
+def load_results(results_dir: pathlib.Path) -> pd.DataFrame:
+    dataframe = pd.DataFrame()
+    for result in results_dir.glob("*.json"):
+        result_df = load_single_result(result)
+        dataframe = pd.concat([dataframe, result_df], axis=1)
+
+    return dataframe
+
+
+def load_experiment_config(exp_config: pathlib.Path) -> tuple:
+    with open(exp_config, "r", encoding="ascii") as conf_stream:
+        try:
+            config = yaml.safe_load(conf_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+            exit(1)
+
+    results_dir = pathlib.Path(config.get("results-dir", "experiment-results")).resolve()
+    base_config = pathlib.Path(config.get("base-config", None)).stem
+    alternative_config = pathlib.Path(config.get("alternative-config", None)).stem
+
+    return (results_dir, base_config, alternative_config)
+
+
+def plot_results(results: pd.DataFrame, base: str, alternative: str):
+    sns.set_theme(style="darkgrid")
+
+    IGNORE_FIRST_N = 10
+    IGNORE_LAST_N = -22
+
+    for graph_type in ("coverage", "execs_sec", "corpus_size"):
+        base_mean = results.iloc[
+            IGNORE_FIRST_N:IGNORE_LAST_N,
+            results.columns.str.contains(f"{graph_type}-bb-coverage-.*-{base}"),
+        ].mean(axis=1)
+        base_std = results.iloc[
+            IGNORE_FIRST_N:IGNORE_LAST_N,
+            results.columns.str.contains(f"{graph_type}-bb-coverage-.*-{base}"),
+        ].std(axis=1)
+
+        alt_mean = results.iloc[
+            IGNORE_FIRST_N:IGNORE_LAST_N,
+            results.columns.str.contains(f"{graph_type}-bb-coverage-.*-{alternative}"),
+        ].mean(axis=1)
+        alt_std = results.iloc[
+            IGNORE_FIRST_N:IGNORE_LAST_N,
+            results.columns.str.contains(f"{graph_type}-bb-coverage-.*-{alternative}"),
+        ].std(axis=1)
+
+        start_time = results.iloc[
+            IGNORE_FIRST_N,
+            results.columns.str.contains("relative_timestamp-bb-coverage-.*-.*"),
+        ].mean()
+        end_time = results.iloc[
+            IGNORE_LAST_N,
+            results.columns.str.contains("relative_timestamp-bb-coverage-.*-.*"),
+        ].mean()
+
+        plt.figure(dpi=150)
+        ax = plt.subplot()
+        ax.xaxis.set_major_formatter(mpl.dates.DateFormatter("%H:%M"))
+        ax.xaxis.set_major_locator(mpl.dates.MinuteLocator(interval=30))
+        ax.set_xlabel("time")
+        ax.set_xlim(
+            pd.to_datetime(start_time - 400, unit="s"), pd.to_datetime(end_time + 400, unit="s")
+        )
+        plt.xticks(rotation=45)
+
+        timestamps = pd.date_range(
+            start=pd.to_datetime(start_time, unit="s"),
+            end=pd.to_datetime(end_time, unit="s"),
+            periods=len(base_mean),
+        )
+
+        ax.plot(
+            timestamps,
+            base_mean,
+            label="no-laf",
+            linewidth=2,
+        )
+        ax.plot(
+            timestamps,
+            alt_mean,
+            label="laf",
+            linestyle="--",
+            linewidth=2,
+        )
+        ax.legend()
+        ax.set(title=graph_type)
+
+        ax.fill_between(
+            timestamps,
+            base_mean - base_std,
+            base_mean + base_std,
+            alpha=0.2,
+        )
+        ax.fill_between(
+            timestamps,
+            alt_mean - alt_std,
+            alt_mean + alt_std,
+            alpha=0.2,
+        )
+
+    COV_ENTRY_N = results.index[-30]
+
+    plt.figure()
+    sns.boxplot(
+        data=pd.DataFrame(
+            {
+                "no-laf": results.loc[
+                    COV_ENTRY_N,
+                    results.columns.str.contains(f"coverage-bb-coverage-.*-{base}"),
+                ],
+                "laf": results.loc[
+                    COV_ENTRY_N,
+                    results.columns.str.contains(f"coverage-bb-coverage-.*-{alternative}"),
+                ],
+            }
+        ),
+    )
+
+    plt.show()
+
+
+def main():
+    parser = ap.ArgumentParser()
+    parser.add_argument(
+        "-b",
+        "--base",
+        type=str,
+        help="Name of the base configuration (e.g. no-laf)",
+    )
+    parser.add_argument(
+        "-a",
+        "--alternative",
+        type=str,
+        help="Name of the alternative configuration (e.g. laf)",
+    )
+    parser.add_argument(
+        "results",
+        type=pathlib.Path,
+        help="Path to the results directory",
+    )
+    args = parser.parse_args()
+
+    base_name = args.base
+    alternative_name = args.alternative
+    results_dir = args.results
+
+    results = load_results(results_dir, base_name, alternative_name)
+    plot_results(results, base_name, alternative_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/base.yaml
+++ b/scripts/base.yaml
@@ -1,0 +1,57 @@
+title: wtf-laf-config
+seed: 1337
+target-dir: .
+
+master:
+  runs: 999000000
+  max_len: 120000
+  name: rizin
+  inputs: inputs
+  outputs: outputs
+
+nodes:
+  bochs-laf-compcov:
+    backend: bochscpu
+    edges: 1
+    compcov: 0
+    laf: 0
+    name: rizin
+    limit: 900000
+
+  bochs-laf:
+    backend: bochscpu
+    edges: 1
+    compcov: 0
+    laf: 0
+    name: rizin
+    limit: 900000
+
+  kvm-none-0:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-1:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-2:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-3:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-4:
+    backend: kvm
+    name: rizin
+    limit: 2
+
+  kvm-none-5:
+    backend: kvm
+    name: rizin
+    limit: 2

--- a/scripts/experiment.yaml
+++ b/scripts/experiment.yaml
@@ -1,0 +1,9 @@
+title: laf-vs-nolaf
+
+round-duration: 21600 # 6 hours
+rounds: 5
+results-dir: laf-vs-nolaf-results
+cov-instructions-limit: 900000
+
+base-config: base.yaml
+alternative-config: alternative.yaml

--- a/scripts/gen_coveragefile_binja.py
+++ b/scripts/gen_coveragefile_binja.py
@@ -9,6 +9,7 @@ from binaryninja import PluginCommand, interaction
 def generate_coverage_file(bv):
     # bv.file.filename: 'C:/path/to/binary.bndb'
     name = Path(bv.file.filename).stem
+    name = name.replace("-", "_")
 
     bb_list = []
 

--- a/scripts/gen_coveragefile_ghidra.py
+++ b/scripts/gen_coveragefile_ghidra.py
@@ -19,7 +19,7 @@ while block:
     block = block_iterator.next()
 
 json_object = {
-    'name': program_name,
+    'name': program_name.replace("-", "_"),
     'addresses': address_list
 }
 

--- a/scripts/gen_coveragefile_ida.py
+++ b/scripts/gen_coveragefile_ida.py
@@ -6399,7 +6399,7 @@ def main():
                 addrs.add(rva)
 
     cov = {
-        'name': filepath.with_suffix('').name,
+        'name': filepath.with_suffix('').name.replace("-", "_"),
         'addresses': sorted(addrs)
     }
 

--- a/scripts/merge_coverage_traces.py
+++ b/scripts/merge_coverage_traces.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+
+"""Merge coverage traces from multiple files into one.
+
+@m4drat - 2023
+"""
+
+
+import argparse
+from pathlib import Path
+from alive_progress import alive_bar
+
+
+def read_file(file_name: str) -> list:
+    with open(file_name, mode="r", encoding="ascii") as cov_file:
+        return cov_file.read().splitlines()
+
+
+def merge_coverage_files(file_names: list, disable_progress: bool = False) -> set:
+    merged: set = set()
+    with alive_bar(
+        len(file_names), title="Merging coverage traces", disable=disable_progress
+    ) as bar:
+        for file_name in file_names:
+            merged.update(read_file(file_name))
+            bar()
+
+    return merged
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--coverage-dir",
+        type=Path,
+        help="Path to directory containing coverage traces",
+        required=True,
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        help="Path to merged coverage trace",
+        default="merged_coverage.trace",
+    )
+    args = p.parse_args()
+
+    cov_merged = merge_coverage_files(list(args.coverage_dir.glob("*.trace")))
+    cov_lines = map(lambda cov_entry: cov_entry + "\n", cov_merged)
+
+    with open(args.output, "w", encoding="ascii") as merged:
+        merged.writelines(cov_lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/monitor-fuzzing-session.py
+++ b/scripts/monitor-fuzzing-session.py
@@ -1,0 +1,281 @@
+#!/usr/bin/python3
+
+"""Monitors a fuzzing session and once in a while generates a BB coverage report.
+
+@m4drat - 2023
+"""
+
+import os
+import json
+import time
+import shutil
+import argparse
+import subprocess
+from pathlib import Path
+from typing import List, Any, Dict
+from merge_coverage_traces import merge_coverage_files
+
+
+def generate_coverage_trace(
+    wtf: Path, target_fuzzer: str, coverage_reports_dir: Path, inputs_dir: Path, instr_limit: int
+) -> bool:
+    """Generate a BB coverage trace for a given testcase.
+
+    Args:
+        wtf (Path): Path to the WTF binary
+        target_fuzzer (str): Name of the target fuzzer
+        coverage_reports_dir (Path): Path where to store the generated coverage trace
+        inputs_dir (Path): Path to the testcases directory
+        instr_limit (int): Maximum number of instructions to execute
+
+    Returns:
+        bool: True if coverage traces were generated successfully, False otherwise
+    """
+
+    # Generate coverage trace
+    p = subprocess.run(
+        [
+            wtf,
+            "run",
+            "--name",
+            target_fuzzer,
+            "--backend=bochscpu",
+            "--state=state",
+            f"--limit={instr_limit}",
+            f"--input={inputs_dir.absolute()}",
+            f"--trace-path={coverage_reports_dir}",
+            "--trace-type=cov",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+    return p.returncode == 0
+
+
+def generate_coverage_traces(
+    wtf: Path, target_fuzzer: str, coverage_traces_dir: Path, new_testcases: set, instr_limit: int
+) -> List[Path]:
+    """Generate BB coverage traces for new testcases.
+
+    Args:
+        wtf (Path): Path to the WTF binary
+        target_fuzzer (str): Name of the target fuzzer
+        coverage_traces_dir (Path): Path where to store the generated coverage traces
+        new_testcases (set): Set of new testcases
+        instr_limit (int): Maximum number of instructions to execute
+
+    Returns:
+        List[Path]: List of generated coverage traces
+    """
+
+    coverage_traces: List[Path] = []
+
+    if len(new_testcases) == 0:
+        return coverage_traces
+
+    # Copy new testcases to the inputs directory
+    testcases_dir = Path(".") / "monitor-inputs"
+    testcases_dir.mkdir(exist_ok=True)
+
+    for testcase in new_testcases:
+        shutil.copy2(testcase, testcases_dir)
+
+        coverage_report_path = coverage_traces_dir / f"{testcase.name}.trace"
+        coverage_traces.append(coverage_report_path)
+
+    if generate_coverage_trace(wtf, target_fuzzer, coverage_traces_dir, testcases_dir, instr_limit) is not True:
+        print(f'Failed to generate coverage traces for "{testcases_dir}"')
+
+    # Remove copied testcases
+    shutil.rmtree(testcases_dir)
+
+    return coverage_traces
+
+
+def extract_execs_sec(log_file: Path = Path("master.log")) -> int:
+    try:
+        last_line = next(reversed(list(open(log_file, "r", encoding="ascii"))))
+        return int(float(last_line.rstrip().split(" ")[8]))
+    except Exception as e:
+        print(f"Failed to extract execs/sec from {log_file}: {e}")
+        return 0
+
+
+def monitor_coverage(
+    wtf: Path,
+    target_fuzzer: str,
+    coverage_traces: Path,
+    aggregated_coverage: Path,
+    output: Path,
+    monitor_interval: int, 
+    instr_limit: int
+):
+    """Monitor a fuzzing session and once in a while generate a BB coverage report.
+
+    Args:
+        wtf (Path): Path to the WTF binary
+        target_fuzzer (str): Name of the target fuzzer
+        coverage_traces (Path): Path where to store generated coverage traces
+        aggregated_coverage (Path): Path where to store the aggregated coverage trace
+        output (Path): Path to the stats output file
+        monitor_interval (int): Interval in seconds between each stats update
+        instr_limit (int): Maximum number of instructions to execute
+    """
+
+    aggregated_coverage.touch()
+    processed_outputs: set = set()
+    merged_coverage: set = set()
+
+    stats: Dict[str, Any] = {
+        "start_time": time.time(),
+        "stats": [
+            {
+                "relative_timestamp": 0,
+                "coverage": 0,
+                "crashes": 0,
+                "execs_sec": 0,
+                "corpus_size": 0,
+            }
+        ],
+    }
+
+    try:
+        while True:
+            outputs = set(Path(".").glob("outputs/*"))
+            new_outputs = outputs - processed_outputs
+
+            timestamp = time.time()
+
+            new_coverage_traces = generate_coverage_traces(
+                wtf, target_fuzzer, coverage_traces, new_outputs, instr_limit
+            )
+
+            if len(new_coverage_traces) > 0:
+                merged_coverage = merge_coverage_files(
+                    [aggregated_coverage] + new_coverage_traces, True
+                )
+            coverage_delta = len(merged_coverage) - stats["stats"][-1]["coverage"]
+
+            total_crashes = len(list(Path(".").glob("crashes/*")))
+            crashes_delta = total_crashes - stats["stats"][-1]["crashes"]
+            execs_sec = extract_execs_sec()
+
+            print(
+                f"[{time.ctime(timestamp)}] Coverage: {len(merged_coverage)} (+{coverage_delta}), "
+                f"Crashes: {total_crashes} (+{crashes_delta}), "
+                f"Testcases: {len(outputs)} +({len(new_outputs)}), "
+                f"Execs/sec: {execs_sec}, Corpus size: {len(processed_outputs)}"
+            )
+
+            entry = {
+                "relative_timestamp": timestamp - stats["start_time"],
+                "coverage": len(merged_coverage),
+                "crashes": total_crashes,
+                "execs_sec": execs_sec,
+                "corpus_size": len(processed_outputs),
+            }
+            stats["stats"].append(entry)
+
+            with open(output, "w", encoding="ascii") as stats_file:
+                json.dump(stats, stats_file, indent=4)
+
+            # Update set of processed outputs
+            processed_outputs.update(new_outputs)
+
+            # Update aggregated coverage
+            if len(new_coverage_traces) > 0:
+                aggregated_coverage.write_text("\n".join(merged_coverage))
+
+            time.sleep(monitor_interval)
+    except KeyboardInterrupt:
+        # Finalize stats
+        with open(output, "w", encoding="ascii") as stats_file:
+            json.dump(stats, stats_file, indent=4)
+
+        print("Monitoring stopped!")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--wtf",
+        type=Path,
+        help="Path to the WTF binary",
+        required=True,
+    )
+    p.add_argument(
+        "--target-dir",
+        type=Path,
+        help="Path to the target directory",
+        required=True,
+    )
+    p.add_argument(
+        "--target-fuzzer",
+        type=str,
+        help="Name of the target fuzzer",
+        required=True,
+    )
+    p.add_argument(
+        "--coverage-traces-dir",
+        type=Path,
+        help="Relative path where to store the coverage traces",
+        default="monitor-coverage-traces",
+    )
+    p.add_argument(
+        "--aggregated-coverage",
+        type=Path,
+        help="Relative path where to store the aggregated coverage trace",
+        default="aggregated_coverage.trace",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        help="Relative path to the stats output file",
+        default="bb_coverage.json",
+    )
+    p.add_argument(
+        "--monitor-interval",
+        type=int,
+        help="Interval in seconds between two stats updates",
+        default=30,
+    )
+    p.add_argument(
+        "--instr-limit",
+        type=int,
+        help="Maximum instructions executed",
+        required=True
+    )
+    args = p.parse_args()
+
+    if not args.target_dir.exists():
+        print(f"Target directory {args.target_dir} does not exist")
+        exit(1)
+
+    # Make sure we are in the target directory
+    os.chdir(args.target_dir)
+
+    # Remove previous artifacts
+    if args.aggregated_coverage.exists():
+        args.aggregated_coverage.unlink()
+
+    if args.coverage_traces_dir.exists():
+        shutil.rmtree(args.coverage_traces_dir, ignore_errors=True)
+
+    if not args.coverage_traces_dir.exists():
+        args.coverage_traces_dir.mkdir()
+
+    monitor_coverage(
+        args.wtf,
+        args.target_fuzzer,
+        args.coverage_traces_dir,
+        args.aggregated_coverage,
+        args.output,
+        args.monitor_interval,
+        args.instr_limit,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-configuration.py
+++ b/scripts/run-configuration.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python3
+
+from termcolor import colored
+from subprocess import Popen, PIPE, DEVNULL, TimeoutExpired
+import yaml
+import argparse
+import pathlib
+import os
+import sys
+import time
+
+
+def start_node(
+    target_dir: pathlib.Path,
+    seed: int,
+    node_name: str,
+    node_conf: dict,
+    master: bool = False,
+) -> Popen:
+    """Start a node.
+
+    Args:
+        target_dir (pathlib.Path): Path to the target directory
+        seed (int): Seed to use
+        node_name (str): Node name
+        node_conf (dict): Node configuration
+        master (bool, optional): Whether this node is the master. Defaults to False.
+
+    Returns:
+        Popen: Popen object for the started node
+    """
+
+    wtf_bin = "wtf.exe" if os.name == "nt" else "wtf"
+
+    if master:
+        args = [
+            wtf_bin,
+            "master",
+            f"--runs={node_conf['runs']}",
+            f"--max_len={node_conf['max_len']}",
+            f"--name={node_conf['name']}",
+            f"--target={target_dir.absolute()}",
+            f"--inputs={node_conf.get('inputs', target_dir / 'inputs')}",
+            f"--outputs={node_conf.get('outputs', target_dir / 'inputs')}",
+            f"--seed={seed}",
+        ]
+    else:
+        # Check whether the backend is bochscpu, bxcpu or 0 (also bochscpu)
+
+        if node_conf["backend"] in ["bochscpu", "bxcpu", "0"]:
+            args = [
+                wtf_bin,
+                "fuzz",
+                f"--backend={node_conf['backend']}",
+                f"--edges={node_conf['edges']}",
+                f"--compcov={node_conf['compcov']}",
+                f"--laf={node_conf['laf']}",
+            ]
+
+            if "laf-allowed-ranges" in node_conf:
+                args.append(f"--laf-allowed-ranges={node_conf['laf-allowed-ranges']}")
+
+            args += [
+                f"--name={node_conf['name']}",
+                f"--target={target_dir.absolute()}",
+                f"--limit={node_conf['limit']}",
+                f"--seed={seed}",
+            ]
+            print(args)
+
+        elif node_conf["backend"] in ["kvm", "whv"]:
+            if node_conf["limit"] > 15:
+                print(
+                    f"{colored('WARNING', 'yellow')}: The limit looks too high for this backend, remember that the limit for KVM/WHV is the number of seconds to run the fuzzing session for"
+                )
+
+            args = [
+                wtf_bin,
+                "fuzz",
+                f"--backend={node_conf['backend']}",
+                f"--name={node_conf['name']}",
+                f"--target={target_dir.absolute()}",
+                f"--limit={node_conf['limit']}",
+                f"--seed={seed}",
+            ]
+
+        else:
+            print(f"Unknown backend: {node_conf['backend']}")
+            exit(1)
+
+    print(f"Starting node: {node_name} with args: {args}")
+
+    # Start the node
+    output = None if master else DEVNULL
+    return Popen(args, stdout=output, stderr=output, bufsize=1, universal_newlines=True)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "config",
+        type=pathlib.Path,
+        help="Path to the configuration file",
+    )
+    args = p.parse_args()
+
+    with open(args.config, "r", encoding="ascii") as conf_stream:
+        try:
+            config = yaml.safe_load(conf_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+            exit(1)
+
+    target_dir = pathlib.Path(config.get("target-dir", os.getcwd())).resolve()
+    seed = config.get("seed", 0)
+    run_for = config.get("run-for", 60 * 60 * 24 * 365 * 10)
+
+    subprocesses = []
+
+    # Start the master node
+    if "master" not in config:
+        print("No master node defined")
+        exit(1)
+
+    subprocesses.append(start_node(target_dir, seed, "master", config["master"], master=True))
+    master = subprocesses[0]
+
+    # Wait for master node to finish
+    try:
+        if master.wait(10) != 0:
+            print("Master node failed to start!")
+            exit(1)
+    except TimeoutExpired:
+        print("Master node succesfully started!")
+
+    # Start all secondary nodes
+    if "nodes" not in config:
+        print("No secondary nodes defined")
+        exit(1)
+
+    for node_name in config["nodes"]:
+        node_conf = config["nodes"][node_name]
+        subprocesses.append(start_node(target_dir, seed, node_name, node_conf))
+
+        last = subprocesses[-1]
+        try:
+            if last.wait(2) != 0:
+                print(f"Fuzzer-node: {node_name} failed to start!")
+                exit(1)
+        except TimeoutExpired:
+            print(f"Fuzzer-node: {node_name} succesfully started!")
+
+    # Wait for master node to finish
+    try:
+        master.wait(run_for)
+    except TimeoutExpired:
+        print("Timeout expired, killing all nodes")
+        master.kill()
+    except KeyboardInterrupt:
+        print("Killing all nodes")
+        master.kill()
+    finally:
+        # Wait for all nodes to finish
+        for node in subprocesses[1:]:
+            node.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-experiments.py
+++ b/scripts/run-experiments.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python3
+
+from subprocess import Popen, PIPE, DEVNULL, TimeoutExpired
+import argparse
+import pathlib
+import yaml
+import os
+import psutil
+import shutil
+import time
+
+WTF_SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent
+
+
+def run_coverage_monitor(fuzzer_name: str, instr_limit: int):
+    wtf_bin = "wtf.exe" if os.name == "nt" else "wtf"
+    run_python = ["py", "-3"] if os.name == "nt" else ["python3"]
+    return Popen(
+        [
+            *run_python,
+            WTF_SCRIPTS_DIR / "monitor-fuzzing-session.py",
+            "--wtf",
+            wtf_bin,
+            "--target-dir=.",
+            f"--target-fuzzer={fuzzer_name}",
+            f"--instr-limit={instr_limit}",
+            "--monitor-interval=15",
+        ],
+        stdout=None,
+        stderr=None,
+        bufsize=1,
+        universal_newlines=True,
+    )
+
+
+def run_configuration(configuration_name: pathlib.Path):
+    run_python = ["py", "-3"] if os.name == "nt" else ["python3"]
+    return Popen(
+        [
+            *run_python,
+            WTF_SCRIPTS_DIR / "run-configuration.py",
+            f"{configuration_name}",
+        ],
+        stdout=None,
+        stderr=None,
+    )
+
+def kill(proc_pid):
+    process = psutil.Process(proc_pid)
+    for proc in process.children(recursive=True):
+        proc.kill()
+    process.kill()
+
+
+def execute_experiment_round(
+    exp_round: int,
+    results_dir: pathlib.Path,
+    round_duration: int,
+    fuzzing_config: pathlib.Path,
+    fuzzer_name: str,
+    instr_limit: int
+) -> bool:
+    coverage_monitor = run_coverage_monitor(fuzzer_name, instr_limit)
+    configuration_executor = run_configuration(fuzzing_config)
+
+    try:
+        if configuration_executor.wait(round_duration) != 0:
+            print("Configuration executor failed")
+            kill(coverage_monitor.pid)
+            return False
+    except TimeoutExpired:
+        print("Round finished, killing processes")
+        kill(configuration_executor.pid)
+        kill(coverage_monitor.pid)
+
+    # Save the results
+    os.rename(
+        "bb_coverage.json", results_dir / f"bb-coverage-{exp_round}-{fuzzing_config.stem}.json"
+    )
+
+    # Clean up
+    outputs_dir = pathlib.Path("./outputs")
+    shutil.rmtree(outputs_dir, ignore_errors=True)
+    outputs_dir.mkdir(parents=True, exist_ok=True)
+
+    crashes_dir = pathlib.Path("./crashes")
+    shutil.rmtree(crashes_dir, ignore_errors=True)
+    crashes_dir.mkdir(parents=True, exist_ok=True)
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "exp_config",
+        type=pathlib.Path,
+        help="Path to the experiment configuration file",
+    )
+    parser.add_argument(
+        "target_fuzzer",
+        type=str,
+        help="Name of the target fuzzer",
+    )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Remove crashes and outputs directories before starting the experiment",
+    )
+    parser.add_argument(
+        "--overwrite-results",
+        action="store_true",
+        help="Overwrite existing results directory",
+    )
+    args = parser.parse_args()
+
+    with open(args.exp_config, "r", encoding="ascii") as conf_stream:
+        try:
+            config = yaml.safe_load(conf_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+            exit(1)
+
+    results_dir = pathlib.Path(config.get("results-dir", "experiment-results")).resolve()
+    round_duration = config.get("round-duration", 6 * 60 * 60)
+    base_config = pathlib.Path(config.get("base-config", None)).resolve()
+    alternative_config = pathlib.Path(config.get("alternative-config", None)).resolve()
+    instr_limit = config["cov-instructions-limit"]
+
+    # Check if outputs/crahes directories are not empty
+    outputs_dir = pathlib.Path("./outputs")
+    crashes_dir = pathlib.Path("./crashes")
+
+    if args.cleanup:
+        shutil.rmtree(outputs_dir, ignore_errors=True)
+        outputs_dir.mkdir(parents=True, exist_ok=True)
+
+        shutil.rmtree(crashes_dir, ignore_errors=True)
+        crashes_dir.mkdir(parents=True, exist_ok=True)
+
+    if len(list(outputs_dir.glob("*"))) > 0 or len(list(crashes_dir.glob("*"))) > 0:
+        print("Outputs/crashes directories are not empty")
+        exit(1)
+
+    if args.overwrite_results and results_dir.exists():
+        print(f"Removing existing results directory {results_dir}")
+        shutil.rmtree(results_dir, ignore_errors=True)
+
+    if results_dir.exists():
+        print(f"Results directory {results_dir} already exists")
+        exit(1)
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    for exp_round in range(config.get("rounds", 1)):
+        print(f"Starting experiment round {exp_round + 1}")
+
+        # Execute the experiment round (alternative)
+        while execute_experiment_round(
+            exp_round,
+            results_dir,
+            round_duration,
+            alternative_config,
+            args.target_fuzzer,
+            instr_limit
+        ) is False:
+            print(f"execute_experiment_round (alt) failed on round: {exp_round + 1}")
+            time.sleep(15)
+
+        # Execute the experiment round (base)
+        while execute_experiment_round(
+            exp_round,
+            results_dir,
+            round_duration,
+            base_config,
+            args.target_fuzzer,
+            instr_limit
+        ) is False:
+            print(f"execute_experiment_round (base) failed on round: {exp_round + 1}")
+            time.sleep(15)
+
+        time.sleep(20)
+
+        # Sleep for some time between rounds
+        time.sleep(20)
+
+    print("All experiments executed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ if (WIN32)
         winhvplatform.lib
         delayimp.lib
         bcrypt.lib
+        ntdll.lib
     )
 
     add_executable(
@@ -102,6 +103,11 @@ if (WIN32)
     add_executable(
         hevd_client
         hevd_client/hevd_client.cc
+    )
+
+    add_executable(
+        fuzzy_goat
+        fuzzy_goat/fuzzy_goat.cc
     )
 else (WIN32)
     enable_language(ASM)

--- a/src/fuzzy_goat/fuzzy_goat.cc
+++ b/src/fuzzy_goat/fuzzy_goat.cc
@@ -1,0 +1,156 @@
+// Theodor Arsenij 'm4drat' - May 23 2023
+
+#define _CRT_SECURE_NO_WARNINGS
+
+#include <Windows.h>
+#include <array>
+#include <cstdio>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+uint32_t FuzzingCoverageFeedbackTest(const char *buffer, uint32_t size) {
+  if (size < 10) {
+    return 0;
+  }
+
+  if (buffer[0] == 'F') {
+    if (buffer[1] == 'U') {
+      if (buffer[2] == 'Z') {
+        if (buffer[3] == 'Z') {
+          if (buffer[4] == 'I') {
+            if (buffer[5] == 'N') {
+              if (buffer[6] == 'G') {
+                if (buffer[7] == '!') {
+                  abort();
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return 1;
+}
+
+uint32_t FuzzingCompcovLafTest(const char *buffer, uint32_t size) {
+  if (size < 112) {
+    return 0;
+  }
+
+  // Check if we can solve 8-byte comparison.
+  if (*(uint64_t *)buffer != 0x13375612DEADBEEF) {
+    return 1;
+  }
+  buffer += sizeof(uint64_t);
+
+  // Check if we can solve 4-byte comparison.
+  if (*(uint32_t *)buffer != 0xDEADBEEF) {
+    return 2;
+  }
+  buffer += sizeof(uint32_t);
+
+  // Check if we can solve 2-byte comparison.
+  if (*(uint16_t *)buffer != 0x1337) {
+    return 3;
+  }
+  buffer += sizeof(uint16_t);
+
+  // strcmp.
+  const char str1[] = "Never gonna";
+  // Here, and below we're calling these functions using volatile function
+  // pointers. This way, the compiler should emit a library-call instead of
+  // inlining the whole function.
+  int (*volatile strcmp_ptr)(const char *_Str1, const char *_Str2) = strcmp;
+  if (strcmp_ptr(buffer, str1) != 0) {
+    return 4;
+  }
+  buffer += sizeof(str1);
+
+  // strncmp.
+  const char str2[] = "give you up";
+  int (*volatile strncmp_ptr)(const char *_Str1, const char *_Str2,
+                              size_t _MaxCount) = strncmp;
+  if (strncmp_ptr(buffer, str2, sizeof(str2)) != 0) {
+    return 5;
+  }
+  buffer += sizeof(str2);
+
+  // memcmp.
+  const char str3[] = "run around";
+  int (*volatile memcmp_ptr)(const void *_Buf1, const void *_Buf2,
+                             size_t _Size) = memcmp;
+  if (memcmp_ptr(buffer, str3, sizeof(str3)) != 0) {
+    return 6;
+  }
+  buffer += sizeof(str3);
+
+  // CompareStringA.
+  const char str4[] = "desert you";
+  // Here, and below we're calling these functions using volatile function
+  // pointers. This way, the compiler should emit a library-call instead of
+  // inlining the whole function.
+  int (*volatile compare_string_a_ptr)(
+      LCID Locale, DWORD dwCmpFlags, PCNZCH lpString1, int cchCount1,
+      PCNZCH lpString2, int cchCount) = CompareStringA;
+  if (compare_string_a_ptr(LOCALE_USER_DEFAULT, 0, str4, sizeof(str4) - 1,
+                           buffer, sizeof(str4) - 1) != CSTR_EQUAL) {
+    return 1;
+  }
+  buffer += sizeof(str4);
+
+  // CompareStringW.
+  const wchar_t str5[] = L"make you cry";
+  int (*volatile compare_string_w_ptr)(
+      LCID Locale, DWORD dwCmpFlags, PCNZWCH lpString1, int cchCount1,
+      PCNZWCH lpString2, int cchCount) = CompareStringW;
+  if (compare_string_w_ptr(LOCALE_USER_DEFAULT, 0, str5, sizeof(str5) / 2 - 1,
+                           (const wchar_t *)buffer,
+                           sizeof(str5) / 2 - 1) != CSTR_EQUAL) {
+    return 2;
+  }
+
+  abort();
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    printf("Usage: %s <test-mode> (compcov-laf, bb-coverage)\n", argv[0]);
+    return 1;
+  }
+
+  std::array<uint8_t, 1024> Buffer;
+
+  // This is a volatile call to memset, to force load the dll.
+  volatile uint64_t res = memcmp(Buffer.data(), Buffer.data(), Buffer.size());
+
+  // This is a volatile call to CompareStringA, to force load the dll.
+  volatile uint64_t res1 =
+      CompareStringA(LOCALE_USER_DEFAULT, 0, "a", 1, "b", 1);
+
+  // This is a volatile call to CompareStringA, to force load the dll.
+  volatile uint64_t res2 =
+      CompareStringW(LOCALE_USER_DEFAULT, 0, L"a", 1, L"b", 1);
+
+  // Allows us to execute the lockmem.exe.
+  std::getc(stdin);
+
+  if (getenv("BREAK") != nullptr) {
+    __debugbreak();
+  }
+
+  if (strcmp(argv[1], "bb-coverage") == 0) {
+    return FuzzingCoverageFeedbackTest((const char *)Buffer.data(),
+                                       Buffer.size());
+  } else if (strcmp(argv[1], "compcov-laf") == 0) {
+    return FuzzingCompcovLafTest((const char *)Buffer.data(), Buffer.size());
+  } else {
+    printf("Usage: %s <test-mode> (compcov-laf, bb-coverage)\n", argv[0]);
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/libs/bochscpu-bins/include/bochscpu.hpp
+++ b/src/libs/bochscpu-bins/include/bochscpu.hpp
@@ -58,6 +58,30 @@ static const uint32_t BOCHSCPU_OPCODE_ERROR = 0;
 
 static const uint32_t BOCHSCPU_OPCODE_INSERTED = 1;
 
+enum class DisasmStyle : uint32_t {
+  Intel = 0,
+  Gas = 1,
+};
+
+enum class GpRegs : uint32_t {
+  Rax = 0,
+  Rcx = 1,
+  Rdx = 2,
+  Rbx = 3,
+  Rsp = 4,
+  Rbp = 5,
+  Rsi = 6,
+  Rdi = 7,
+  R8 = 8,
+  R9 = 9,
+  R10 = 10,
+  R11 = 11,
+  R12 = 12,
+  R13 = 13,
+  R14 = 14,
+  R15 = 15,
+};
+
 using bochscpu_cpu_t = void*;
 
 /// FFI Hook object
@@ -211,6 +235,8 @@ void bochscpu_cpu_delete(bochscpu_cpu_t p);
 
 void bochscpu_cpu_set_mode(bochscpu_cpu_t p);
 
+uint32_t bochscpu_total_gpregs();
+
 /// Start emulation
 ///
 /// To hook emulation, pass in a NULL terminated list of one or more pointers to
@@ -228,6 +254,18 @@ void bochscpu_cpu_set_state(bochscpu_cpu_t p, const bochscpu_cpu_state_t *s);
 void bochscpu_cpu_set_state_no_flush(bochscpu_cpu_t p, const bochscpu_cpu_state_t *s);
 
 void bochscpu_cpu_set_exception(bochscpu_cpu_t p, uint32_t vector, uint16_t error);
+
+uint64_t bochscpu_get_reg64(bochscpu_cpu_t p, GpRegs reg);
+
+void bochscpu_set_reg64(bochscpu_cpu_t p, GpRegs reg, uint64_t val);
+
+uint32_t bochscpu_get_reg32(bochscpu_cpu_t p, GpRegs reg);
+
+void bochscpu_set_reg32(bochscpu_cpu_t p, GpRegs reg, uint32_t val);
+
+uint16_t bochscpu_get_reg16(bochscpu_cpu_t p, GpRegs reg);
+
+void bochscpu_set_reg16(bochscpu_cpu_t p, GpRegs reg, uint16_t val);
 
 uint64_t bochscpu_cpu_rax(bochscpu_cpu_t p);
 
@@ -360,6 +398,24 @@ uint16_t bochscpu_instr_imm16(bochscpu_instr_t p);
 uint32_t bochscpu_instr_imm32(bochscpu_instr_t p);
 
 uint64_t bochscpu_instr_imm64(bochscpu_instr_t p);
+
+uint32_t bochscpu_instr_src(bochscpu_instr_t p);
+
+uint32_t bochscpu_instr_dst(bochscpu_instr_t p);
+
+uint32_t bochscpu_instr_seg(bochscpu_instr_t p);
+
+uint32_t bochscpu_instr_modC0(bochscpu_instr_t p);
+
+uint64_t bochscpu_instr_resolve_addr(bochscpu_instr_t p);
+
+uint32_t bochscpu_opcode_disasm(uint32_t is32,
+                                uint32_t is64,
+                                Address *cs_base,
+                                Address *ip,
+                                uint8_t *instr_bytes,
+                                const char *distbuf,
+                                DisasmStyle disasm_style);
 
 /// Add GPA mapping to HVA
 ///

--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -38,7 +38,6 @@ bool Backend_t::VirtRead(const Gva_t Gva, uint8_t *Buffer,
 
     if (!Translate) {
       fmt::print("Translation of GVA {:#x} failed\n", CurrentGva);
-      __debugbreak();
       return false;
     }
 
@@ -53,6 +52,14 @@ bool Backend_t::VirtRead(const Gva_t Gva, uint8_t *Buffer,
   }
 
   return true;
+}
+
+uint16_t Backend_t::VirtRead2(const Gva_t Gva) const {
+  uint16_t Ret = 0;
+  if (!VirtReadStruct(Gva, &Ret)) {
+    __debugbreak();
+  }
+  return Ret;
 }
 
 uint32_t Backend_t::VirtRead4(const Gva_t Gva) const {

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -313,6 +313,12 @@ public:
   }
 
   //
+  // Read a uint16_t.
+  //
+
+  uint16_t VirtRead2(const Gva_t Gva) const;
+
+  //
   // Read a uint32_t.
   //
 
@@ -503,7 +509,6 @@ public:
   [[nodiscard]] std::pair<uint64_t, Gva_t> GetArgAndAddress(const uint64_t Idx);
   [[nodiscard]] std::pair<Gva_t, Gva_t> GetArgAndAddressGva(const uint64_t Idx);
 
-
   //
   // Shortcuts to grab / set some registers.
   //
@@ -587,6 +592,12 @@ public:
   //
 
   virtual bool RevokeLastNewCoverage() = 0;
+
+  //
+  // Inserts a new coverage entry.
+  //
+
+  virtual bool InsertCoverageEntry(const Gva_t Gva) = 0;
 
   //
   // Print the registers.

--- a/src/wtf/bochscpu_backend.h
+++ b/src/wtf/bochscpu_backend.h
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <functional>
+#include <stdexcept>
 
 struct BochscpuRunStats_t {
   uint64_t NumberInstructionsExecuted = 0;
@@ -21,6 +22,10 @@ struct BochscpuRunStats_t {
   uint64_t DirtyGpas = 0;
   uint64_t NumberEdges = 0;
   uint64_t NumberUniqueEdges = 0;
+  uint64_t NumberLafCmpHits = 0;
+  uint64_t NumberLafUniqueCmpHits = 0;
+  uint64_t NumberCompcovHits = 0;
+  uint64_t NumberCompcovUniqueHits = 0;
 
   void Print() const {
     fmt::print("--------------------------------------------------\n");
@@ -34,6 +39,11 @@ struct BochscpuRunStats_t {
                BytesToHuman(NumberMemoryAccesses));
     fmt::print("       Edges executed: {} ({} unique)\n",
                NumberToHuman(NumberEdges), NumberToHuman(NumberUniqueEdges));
+    fmt::print("      LAF hits: {} ({} new)\n", NumberToHuman(NumberLafCmpHits),
+               NumberToHuman(NumberLafUniqueCmpHits));
+    fmt::print("  CompCov hits: {} ({} new)\n",
+               NumberToHuman(NumberCompcovHits),
+               NumberToHuman(NumberCompcovUniqueHits));
   }
 
   void Reset() {
@@ -41,6 +51,8 @@ struct BochscpuRunStats_t {
     NumberMemoryAccesses = 0;
     NumberEdges = 0;
     NumberUniqueEdges = 0;
+    NumberLafUniqueCmpHits = 0;
+    NumberCompcovUniqueHits = 0;
   }
 };
 
@@ -131,6 +143,18 @@ class BochscpuBackend_t : public Backend_t {
 
     std::vector<BochscpuMemAccess_t> MemAccesses_;
   } Tenet_;
+
+  //
+  // Enable/disable the LAF.
+  //
+
+  LafCompcovOptions_t LafMode_ = LafCompcovOptions_t::Disabled;
+
+  //
+  // Allowed ranges for the LAF.
+  //
+
+  std::vector<std::pair<Gva_t, Gva_t>> LafAllowedRanges_;
 
   //
   // The hooks we define onto the Cpu.
@@ -229,6 +253,8 @@ public:
 
   void PrintRunStats() override;
 
+  void IncCompcovUniqueHits();
+
   //
   // Non-determinism.
   //
@@ -267,6 +293,8 @@ public:
   const tsl::robin_set<Gva_t> &LastNewCoverage() const override;
 
   bool RevokeLastNewCoverage() override;
+
+  bool InsertCoverageEntry(const Gva_t Gva) override;
 
   //
   // Hooks.
@@ -324,4 +352,576 @@ private:
   //
 
   void DumpTenetDelta(const bool Force = false);
+
+  //
+  // LAF/CompCov support.
+  //
+
+  static constexpr bool LafCompcovLoggingOn = false;
+
+  template <typename... Args_t>
+  void LafCompcovDebugPrint(const char *Format, const Args_t &...args) {
+    if constexpr (LafCompcovLoggingOn) {
+      fmt::print("laf/compcov: ");
+      fmt::print(fmt::runtime(Format), args...);
+    }
+  }
+
+  //
+  // Enum of the Bochs comparison-like instructions. This should be kept in sync
+  // with the Bochs. Handling logic can be found in bochs/cpu/arith32.cpp.
+  //
+
+  enum class BochsIns_t : uint32_t {
+    //
+    // 64-bit comparison instructions.
+    //
+    BX_IA_CMP_RAXId = 0x491,
+    BX_IA_CMP_EqsIb = 0x4a3,
+    BX_IA_CMP_EqId = 0x49a, // CMP_EqIdM, CMP_EqIdR
+    BX_IA_CMP_GqEq = 0x47f, // CMP_GqEqM, CMP_GqEqR
+    BX_IA_CMP_EqGq = 0x488, // CMP_EqGqM
+
+    //
+    // 32-bit comparison instructions.
+    //
+    BX_IA_CMP_EAXId = 0x38,
+    BX_IA_CMP_EdsIb = 0x6a,
+    BX_IA_CMP_EdId = 0x61, // CMP_EdIdM, CMP_EdIdR
+    BX_IA_CMP_GdEd = 0x86, // CMP_GdEdM, CMP_GdEdR
+    BX_IA_CMP_EdGd = 0x1d, // CMP_EdGdM
+
+    //
+    // 16-bit comparison instructions.
+    //
+    BX_IA_CMP_AXIw = 0x2f,
+    BX_IA_CMP_EwsIb = 0x58,
+    BX_IA_CMP_EwIw = 0x4f, // CMP_EwIwM, CMP_EwIwR
+    BX_IA_CMP_GwEw = 0x7e, // CMP_GwEwM, CMP_GwEwR
+    BX_IA_CMP_EwGw = 0x14, // CMP_EwGwM
+
+    //
+    // 64-bit subtraction instructions.
+    //
+    BX_IA_SUB_RAXId = 0x48e,
+    BX_IA_SUB_EqsIb = 0x4a0,
+    BX_IA_SUB_EqId = 0x497, // SUB_EqIdM, SUB_EqIdR
+    BX_IA_SUB_GqEq = 0x47d, // SUB_GqEqM, SUB_GqEqR
+    BX_IA_SUB_EqGq = 0x485, // SUB_EqGqM
+
+    //
+    // 32-bit subtraction instructions.
+    //
+    BX_IA_SUB_EAXId = 0x3b,
+    BX_IA_SUB_EdsIb = 0x67,
+    BX_IA_SUB_EdId = 0x5e, // SUB_EdIdM, SUB_EdIdR
+    BX_IA_SUB_GdEd = 0x89, // SUB_GdEdM, SUB_GdEdR
+    BX_IA_SUB_EdGd = 0x20, // SUB_EdGdM
+
+    //
+    // 16-bit subtraction instructions.
+    //
+    BX_IA_SUB_AXIw = 0x32,
+    BX_IA_SUB_EwsIb = 0x55,
+    BX_IA_SUB_EwIw = 0x4c, // SUB_EwIwM, SUB_EwIwR
+    BX_IA_SUB_GwEw = 0x81, // SUB_GwEwM, SUB_GwEwR
+    BX_IA_SUB_EwGw = 0x17  // SUB_EwGwM
+  };
+
+  //
+  // Converts BochsIns_t to a string.
+  //
+
+  std::string_view BochsInsToString(const BochsIns_t Ins) {
+    switch (Ins) {
+
+    // 64-bit comparison instructions.
+    case BochsIns_t::BX_IA_CMP_RAXId:
+      return "CMP_RAXId";
+    case BochsIns_t::BX_IA_CMP_EqsIb:
+      return "CMP_EqsIb";
+    case BochsIns_t::BX_IA_CMP_EqId:
+      return "CMP_EqId";
+    case BochsIns_t::BX_IA_CMP_GqEq:
+      return "CMP_GqEq";
+    case BochsIns_t::BX_IA_CMP_EqGq:
+      return "CMP_EqGq";
+
+    // 32-bit comparison instructions.
+    case BochsIns_t::BX_IA_CMP_EAXId:
+      return "CMP_EAXId";
+    case BochsIns_t::BX_IA_CMP_EdsIb:
+      return "CMP_EdsIb";
+    case BochsIns_t::BX_IA_CMP_EdId:
+      return "CMP_EdId";
+    case BochsIns_t::BX_IA_CMP_GdEd:
+      return "CMP_GdEd";
+    case BochsIns_t::BX_IA_CMP_EdGd:
+      return "CMP_EdGd";
+
+    // 16-bit comparison instructions.
+    case BochsIns_t::BX_IA_CMP_AXIw:
+      return "CMP_AXIw";
+    case BochsIns_t::BX_IA_CMP_EwsIb:
+      return "CMP_EwsIb";
+    case BochsIns_t::BX_IA_CMP_EwIw:
+      return "CMP_EwIw";
+    case BochsIns_t::BX_IA_CMP_GwEw:
+      return "CMP_GwEw";
+    case BochsIns_t::BX_IA_CMP_EwGw:
+      return "CMP_EwGw";
+
+    // 64-bit subtraction instructions.
+    case BochsIns_t::BX_IA_SUB_RAXId:
+      return "SUB_RAXId";
+    case BochsIns_t::BX_IA_SUB_EqsIb:
+      return "SUB_EqsIb";
+    case BochsIns_t::BX_IA_SUB_EqId:
+      return "SUB_EqId";
+    case BochsIns_t::BX_IA_SUB_GqEq:
+      return "SUB_GqEq";
+    case BochsIns_t::BX_IA_SUB_EqGq:
+      return "SUB_EqGq";
+
+    // 32-bit subtraction instructions.
+    case BochsIns_t::BX_IA_SUB_EAXId:
+      return "SUB_EAXId";
+    case BochsIns_t::BX_IA_SUB_EdsIb:
+      return "SUB_EdsIb";
+    case BochsIns_t::BX_IA_SUB_EdId:
+      return "SUB_EdId";
+    case BochsIns_t::BX_IA_SUB_GdEd:
+      return "SUB_GdEd";
+    case BochsIns_t::BX_IA_SUB_EdGd:
+      return "SUB_EdGd";
+
+    // 16-bit subtraction instructions.
+    case BochsIns_t::BX_IA_SUB_AXIw:
+      return "SUB_AXIw";
+    case BochsIns_t::BX_IA_SUB_EwsIb:
+      return "SUB_EwsIb";
+    case BochsIns_t::BX_IA_SUB_EwIw:
+      return "SUB_EwIw";
+    case BochsIns_t::BX_IA_SUB_GwEw:
+      return "SUB_GwEw";
+    case BochsIns_t::BX_IA_SUB_EwGw:
+      return "SUB_EwGw";
+    }
+
+    return "<unknown>";
+  }
+
+  //
+  // Enum of instruction addressing modes.
+  //
+
+  enum class InsAddressingMode_t : uint8_t { Mem = 0, Reg = 16 };
+
+  //
+  // Get the addressing mode of a Bochs instruction.
+  //
+
+  InsAddressingMode_t BochsInsAddressingMode(bochscpu_instr_t *Ins) {
+    const uint32_t modc0 = bochscpu_instr_modC0(Ins);
+    if (modc0 == 16) {
+      return InsAddressingMode_t::Reg;
+    } else if (modc0 == 0) {
+      return InsAddressingMode_t::Mem;
+    }
+
+    throw std::runtime_error("unknown addressing mode");
+  }
+
+  //
+  // Convert an instruction addressing mode to a string.
+  //
+
+  std::string_view
+  BochsInsAddressingModeToString(const InsAddressingMode_t Mode) {
+    switch (Mode) {
+    case InsAddressingMode_t::Mem:
+      return "Mem";
+    case InsAddressingMode_t::Reg:
+      return "Reg";
+    }
+
+    return "<unknown>";
+  }
+
+  /**
+   * Extracts current privilege level from the CS register.
+   * @see Vol3A[5.5(PRIVILEGE LEVELS)] (reference)
+   */
+
+  inline uint64_t BochsCpuPrivLevel() {
+    Seg cs;
+    bochscpu_cpu_cs(Cpu_, &cs);
+    return cs.selector & 0b11;
+  }
+
+  inline bool BochsCpuIsUserMode() {
+    const uint16_t privlevel = BochsCpuPrivLevel();
+    return privlevel == 3;
+  }
+
+  inline bool BochsCpuIsKernelMode() {
+    const uint16_t privlevel = BochsCpuPrivLevel();
+    return privlevel == 0;
+  }
+
+  //
+  // Operand pair for CMP instructions.
+  //
+
+  template <class T> struct OpPair_t {
+    T Op1;
+    T Op2;
+  };
+
+  using OpPair64_t = OpPair_t<uint64_t>;
+  using OpPair32_t = OpPair_t<uint32_t>;
+  using OpPair16_t = OpPair_t<uint16_t>;
+
+  //
+  // Check if a register is a general purpose register.
+  //
+
+  bool IsGpReg(const uint32_t RegId) { return RegId < bochscpu_total_gpregs(); }
+
+  //
+  // Log the result of operands extraction.
+  //
+
+  template <class T>
+  void LafCompcovLogInstruction(bochscpu_instr_t *Ins,
+                                const std::optional<OpPair_t<T>> Operands) {
+    if constexpr (LafCompcovLoggingOn) {
+      const Gva_t Rip = Gva_t(bochscpu_cpu_rip(Cpu_));
+
+      //
+      // Disassemble the instruction.
+      //
+
+      std::array<uint8_t, 128> InstructionBuffer;
+      VirtRead(Rip, InstructionBuffer.data(), sizeof(InstructionBuffer));
+
+      std::array<char, 256> DisasmBuffer;
+      bochscpu_opcode_disasm(1, 1, 0, 0, InstructionBuffer.data(),
+                             DisasmBuffer.data(), DisasmStyle::Intel);
+      const std::string DisasmString(DisasmBuffer.data());
+
+      //
+      // Extract Bochs instruction type and addressing mode.
+      //
+
+      const std::string_view CmpInstrType = BochsInsToString(
+          static_cast<BochsIns_t>(bochscpu_instr_bx_opcode(Ins)));
+      const std::string_view AddressingMode =
+          BochsInsAddressingModeToString(BochsInsAddressingMode(Ins));
+
+      if (!Operands.has_value()) {
+        LafCompcovDebugPrint(
+            "Extraction failed for instruction : (EL{}) {:#18x} {:46} "
+            "-> {}{}(XXX, XXX)\n",
+            BochsCpuPrivLevel(), Rip, DisasmString, CmpInstrType,
+            AddressingMode);
+        return;
+      }
+
+      LafCompcovDebugPrint("Extracted operands for instruction: (EL{}) {:#18x} "
+                           "{:46} "
+                           "-> {}{}({:#x}, {:#x})\n",
+                           BochsCpuPrivLevel(), Rip, DisasmString, CmpInstrType,
+                           AddressingMode, Operands->Op1, Operands->Op2);
+    }
+  }
+
+  //
+  // LAF entry point. Tries to split various types of comparisons/substractions
+  // into smaller comparisons/substractions. (e.g. 64-bit -> 8 x 8-bit, 32-bit
+  // -> 4 x 8-bit, etc)
+  //
+
+  void LafSplitCompares(bochscpu_instr_t *Ins);
+
+  //
+  // LAF generic handlers for 64-bit, 32-bit and 16-bit integer
+  // comparisons/subtractions.
+  //
+
+  void LafHandle64BitIntCmp(const uint64_t Op1, const uint64_t Op2);
+  void LafHandle32BitIntCmp(const uint32_t Op1, const uint32_t Op2);
+  void LafHandle16BitIntCmp(const uint16_t Op1, const uint16_t Op2);
+
+  //
+  // Extracts immediate operand from a Bochs instruction.
+  //
+
+  template <typename T> T LafBochsInstrImm(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsInstrImm");
+
+    if constexpr (std::is_same<T, uint64_t>::value) {
+      return bochscpu_instr_imm64(Ins);
+    } else if constexpr (std::is_same<T, uint32_t>::value) {
+      return bochscpu_instr_imm32(Ins);
+    } else if constexpr (std::is_same<T, uint16_t>::value) {
+      return bochscpu_instr_imm16(Ins);
+    }
+  }
+
+  //
+  // Reads a general-purpose register given its ID from the Bochs CPU.
+  //
+
+  template <typename T> T LafBochsGetGpReg(const GpRegs GpReg) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsGetGpReg");
+
+    if (!IsGpReg((uint32_t)GpReg)) {
+      LafCompcovDebugPrint("Invalid general-purpose register ID {}\n", GpReg);
+      throw std::runtime_error("Invalid general-purpose register ID");
+    }
+
+    if constexpr (std::is_same<T, uint64_t>::value) {
+      return bochscpu_get_reg64(Cpu_, GpReg);
+    } else if constexpr (std::is_same<T, uint32_t>::value) {
+      return bochscpu_get_reg32(Cpu_, GpReg);
+    } else if constexpr (std::is_same<T, uint16_t>::value) {
+      return bochscpu_get_reg16(Cpu_, GpReg);
+    }
+  }
+
+  //
+  // CMP/SUB instruction handling logic below.
+  //
+
+  //
+  // Extracts operands for CMP/SUB instructions which compare an effective value
+  // (memory) with an immediate. (CMP_EqIdM, CMP_EdIdM, CMP_EwIwM)
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_EIMem(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsInstrReg");
+
+    OpPair_t<T> Res = {};
+
+    // Extract the first operand (memory location).
+    const Gva_t Address = Gva_t(bochscpu_instr_resolve_addr(Ins));
+    if (!VirtReadStruct(Address, &Res.Op1)) {
+      return {};
+    }
+
+    // Extract the second operand (immediate)
+    Res.Op2 = LafBochsInstrImm<T>(Ins);
+
+    return Res;
+  }
+
+  //
+  // Extracts operands for CMP/SUB instructions which compare an effective value
+  // (register) with an immediate. (CMP_EqIdR, CMP_EdIdR, CMP_EwIwR)
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_EIReg(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsInstrReg");
+
+    OpPair_t<T> Res = {};
+    const GpRegs GpReg = (GpRegs)bochscpu_instr_dst(Ins);
+
+    // Extract the first operand (effective value from register).
+    Res.Op1 = LafBochsGetGpReg<T>(GpReg);
+    // Extract the second operand (immediate)
+    Res.Op2 = LafBochsInstrImm<T>(Ins);
+
+    return Res;
+  }
+
+  //
+  // Generic operands extractor for CMP/SUB instructions which compare an
+  // effective value with immediate (sign-extended) (either memory or register).
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_EsI(bochscpu_instr_t *Ins) {
+    //
+    // Extract operands depending on the addressing mode.
+    //
+
+    const InsAddressingMode_t AddrMod = BochsInsAddressingMode(Ins);
+    if (AddrMod == InsAddressingMode_t::Mem) {
+      return LafExtractOperands_EIMem<T>(Ins);
+    } else if (AddrMod == InsAddressingMode_t::Reg) {
+      return LafExtractOperands_EIReg<T>(Ins);
+    }
+
+    LafCompcovDebugPrint("Invalid AddrMod for CMP_EsI\n");
+    return {};
+  }
+
+  //
+  // Generic operands extractor for CMP/SUB instructions which compare an
+  // effective value with immediate (either memory or register).
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_EI(bochscpu_instr_t *Ins) {
+    //
+    // Extract operands depending on the addressing mode.
+    //
+
+    const InsAddressingMode_t AddrMod = BochsInsAddressingMode(Ins);
+    if (AddrMod == InsAddressingMode_t::Mem) {
+      return LafExtractOperands_EIMem<T>(Ins);
+    } else if (AddrMod == InsAddressingMode_t::Reg) {
+      return LafExtractOperands_EIReg<T>(Ins);
+    }
+
+    LafCompcovDebugPrint("Invalid AddrMod for CMP_EI\n");
+    return {};
+  }
+
+  //
+  // Generic operands extractor for CMP/SUB instructions which compare a
+  // register (only rax/eax/ax) with an immediate.
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_REGI(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for CMP_REGI");
+    // This instruction only supports rax/eax/ax, so we don't really need a new
+    // handler, we can just use the one for CMP_EIReg.
+    return LafExtractOperands_EIReg<T>(Ins);
+  }
+
+  //
+  // Extracts operands for CMP/SUB instructions which compare a general purpose
+  // register with an effective value (memory). (CMP_GqEqM, CMP_GdEdM,
+  // CMP_GwEwM).
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_GEMem(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsInstrReg");
+
+    OpPair_t<T> Res = {};
+
+    // Extract the first operand (general purpose register).
+    const GpRegs GpReg = (GpRegs)bochscpu_instr_dst(Ins);
+    Res.Op1 = LafBochsGetGpReg<T>(GpReg);
+
+    // Extract the second operand from memory.
+    const Gva_t Address = Gva_t(bochscpu_instr_resolve_addr(Ins));
+    if (!VirtReadStruct(Address, &Res.Op2)) {
+      return {};
+    }
+
+    return Res;
+  }
+
+  //
+  // Extracts operands for CMP/SUB instructions which compare a general purpose
+  // register with an effective value (register). (CMP_GqEqR, CMP_GdEdR,
+  // CMP_GwEwR).
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_GEReg(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsInstrReg");
+
+    OpPair_t<T> Res = {};
+    const GpRegs GpReg1 = (GpRegs)bochscpu_instr_dst(Ins);
+    const GpRegs GpReg2 = (GpRegs)bochscpu_instr_src(Ins);
+
+    // Extract the first operand (general purpose register).
+    Res.Op1 = LafBochsGetGpReg<T>(GpReg1);
+    // Extract the second operand (general purpose register?).
+    Res.Op2 = LafBochsGetGpReg<T>(GpReg2);
+
+    return Res;
+  }
+
+  //
+  // Generic operands extractor for CMP/SUB instructions which compare a general
+  // purpose register with an effective value (memory or register).
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_GE(bochscpu_instr_t *Ins) {
+    //
+    // Extract operands depending on the addressing mode.
+    //
+
+    const InsAddressingMode_t AddrMod = BochsInsAddressingMode(Ins);
+    if (AddrMod == InsAddressingMode_t::Mem) {
+      return LafExtractOperands_GEMem<T>(Ins);
+    } else if (AddrMod == InsAddressingMode_t::Reg) {
+      return LafExtractOperands_GEReg<T>(Ins);
+    }
+
+    LafCompcovDebugPrint("Invalid AddrMod for CMP_GE\n");
+    return {};
+  }
+
+  //
+  // Extracts operands for CMP/SUB instructions which compare an effective value
+  // (memory) with a general purpose register. (CMP_EqGqM, CMP_EdGdM,
+  // CMP_EwGwM).
+  //
+
+  template <typename T>
+  std::optional<OpPair_t<T>> LafExtractOperands_EG(bochscpu_instr_t *Ins) {
+    static_assert(std::is_same<T, uint64_t>::value ||
+                      std::is_same<T, uint32_t>::value ||
+                      std::is_same<T, uint16_t>::value,
+                  "Invalid operand size for LafBochsInstrReg");
+    OpPair_t<T> Res = {};
+
+    // Extract the first operand - effective value from memory.
+    const Gva_t Address = Gva_t(bochscpu_instr_resolve_addr(Ins));
+    if (!VirtReadStruct(Address, &Res.Op1)) {
+      return {};
+    }
+
+    // Extract the second operand - general purpose register.
+    const GpRegs GpReg = (GpRegs)bochscpu_instr_src(Ins);
+    Res.Op2 = LafBochsGetGpReg<T>(GpReg);
+
+    return Res;
+  }
+
+  //
+  // Tries to split an integer comparison/substraction.
+  //
+
+  bool LafTrySplitIntCmpSub(bochscpu_instr_t *Ins);
+
+  //
+  // Comparison/Substraction operands extraction.
+  //
+
+  std::optional<OpPair64_t> LafExtract64BitOperands(bochscpu_instr_t *Ins);
+  std::optional<OpPair32_t> LafExtract32BitOperands(bochscpu_instr_t *Ins);
+  std::optional<OpPair16_t> LafExtract16BitOperands(bochscpu_instr_t *Ins);
 };

--- a/src/wtf/compcov.cc
+++ b/src/wtf/compcov.cc
@@ -1,0 +1,852 @@
+// Theodor Arsenij 'm4drat' - May 23 2023
+
+#include "compcov.h"
+#include "backend.h"
+#include "debugger.h"
+#include "fmt/core.h"
+#include "globals.h"
+#include "nt.h"
+#include "utils.h"
+#include <fmt/format.h>
+#include <string_view>
+#include <vector>
+
+constexpr bool CompcovLoggingOn = false;
+
+template <typename... Args_t>
+void CompcovPrint(const char *Format, const Args_t &...args) {
+  if constexpr (CompcovLoggingOn) {
+    fmt::print("compcov: ");
+    fmt::print(fmt::runtime(Format), args...);
+  }
+}
+
+//
+// Get the minimum length of two strings, clamping at max_length.
+//
+
+template <class T>
+uint64_t CompcovStrlen2(const T *s1, const T *s2, uint64_t max_length) {
+
+  // from https://github.com/googleprojectzero/CompareCoverage
+
+  size_t len = 0;
+  for (; len < max_length && s1[len] != 0x0 && s2[len] != 0x0; len++) {
+  }
+
+  return len;
+}
+
+//
+// Do a comparison of two buffers and update the coverage accordingly.
+//
+
+template <class T>
+void CompcovTrace(const uint64_t RetLoc, const T *Buffer1, const T *Buffer2,
+                  const uint64_t Length) {
+  BochscpuBackend_t *BochsBackend =
+      dynamic_cast<BochscpuBackend_t *>(g_Backend);
+  if (!BochsBackend) {
+    throw std::runtime_error("CompcovTrace: Unsupported backend, only BochsCPU "
+                             "backend is supported");
+  }
+
+  uint64_t HashedLoc = SplitMix64(RetLoc);
+  for (uint32_t i = 0; i < Length && Buffer1[i] == Buffer2[i]; i++) {
+    if (BochsBackend->InsertCoverageEntry(Gva_t(HashedLoc + i)))
+      BochsBackend->IncCompcovUniqueHits();
+  }
+}
+
+//
+// Generic handler for strcmp-like functions.
+//
+
+void CompcovHandleStrcmp(Backend_t *Backend, Gva_t Str1Ptr, Gva_t Str2Ptr) {
+  //
+  // Read the strings.
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH + 1> Str1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH + 1> Str2{};
+
+  bool Str1ReadRes =
+      Backend->VirtRead(Str1Ptr, Str1.data(), COMPCOV_MAX_CMP_LENGTH);
+  bool Str2ReadRes =
+      Backend->VirtRead(Str2Ptr, Str2.data(), COMPCOV_MAX_CMP_LENGTH);
+
+  //
+  // Check whether we were able to read the strings.
+  //
+
+  if (!Str1ReadRes || !Str2ReadRes) {
+    CompcovPrint("{}: Failed to read strings\n", __func__);
+    return;
+  }
+
+  uint64_t Length =
+      CompcovStrlen2(Str1.data(), Str2.data(), COMPCOV_MAX_CMP_LENGTH);
+
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (Length >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint("{}: MaxCount >= COMPCOV_MAX_CMP_LENGTH\n", __func__);
+    return;
+  }
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("Strcmp(\"{}\", \"{}\", {}) -> {:#x}\n", (char *)Str1.data(),
+               (char *)Str2.data(), Length, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Str1.data(), Str2.data(), Length);
+}
+
+//
+// Strcmp hook.
+//
+
+void CompcovHookStrcmp(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  Gva_t Str1Ptr = Gva_t(Backend->GetArg(0));
+  Gva_t Str2Ptr = Gva_t(Backend->GetArg(1));
+
+  CompcovHandleStrcmp(Backend, Str1Ptr, Str2Ptr);
+}
+
+//
+// Generic handler for strncmp-like functions.
+//
+
+void CompcovHandleStrncmp(Backend_t *Backend, Gva_t Str1Ptr, Gva_t Str2Ptr,
+                          uint64_t MaxCount) {
+
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (MaxCount >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint("{}: MaxCount >= COMPCOV_MAX_CMP_LENGTH\n", __func__);
+    return;
+  }
+
+  //
+  // Read the strings.
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH + 1> Str1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH + 1> Str2{};
+
+  bool Str1ReadRes = Backend->VirtRead(Str1Ptr, Str1.data(), MaxCount);
+  bool Str2ReadRes = Backend->VirtRead(Str2Ptr, Str2.data(), MaxCount);
+
+  //
+  // Check whether we were able to read the strings.
+  //
+
+  if (!Str1ReadRes || !Str2ReadRes) {
+    CompcovPrint("{}: Failed to read strings\n", __func__);
+    return;
+  }
+
+  uint64_t Length = CompcovStrlen2(Str1.data(), Str2.data(), MaxCount);
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("Strncmp(\"{}\", \"{}\", {}) -> {:#x}\n", (char *)Str1.data(),
+               (char *)Str2.data(), Length, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Str1.data(), Str2.data(), Length);
+}
+
+//
+// Strncmp hook.
+//
+
+void CompcovHookStrncmp(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  Gva_t Str1Ptr = Gva_t(Backend->GetArg(0));
+  Gva_t Str2Ptr = Gva_t(Backend->GetArg(1));
+  uint64_t MaxCount = Backend->GetArg(2);
+
+  CompcovHandleStrncmp(Backend, Str1Ptr, Str2Ptr, MaxCount);
+}
+
+//
+// Generic handler for wcscmp-like functions.
+//
+
+void CompcovHandleWcscmp(Backend_t *Backend, Gva_t Wstr1Ptr, Gva_t Wstr2Ptr) {
+  //
+  // Read the strings (still as uint8_t, as we don't want to deal with
+  // wchar_t)
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Wstr1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Wstr2{};
+
+  bool Wstr1ReadRes =
+      Backend->VirtRead(Wstr1Ptr, Wstr1.data(), COMPCOV_MAX_CMP_LENGTH);
+  bool Wstr2ReadRes =
+      Backend->VirtRead(Wstr2Ptr, Wstr2.data(), COMPCOV_MAX_CMP_LENGTH);
+
+  //
+  // Check whether we were able to read the strings.
+  //
+
+  if (!Wstr1ReadRes || !Wstr2ReadRes) {
+    CompcovPrint("{}: Failed to read strings\n", __func__);
+    return;
+  }
+
+  //
+  // Calculate the length of the strings in bytes.
+  //
+
+  uint64_t Length =
+      CompcovStrlen2((uint16_t *)Wstr1.data(), (uint16_t *)Wstr2.data(),
+                     COMPCOV_MAX_CMP_LENGTH / 2) *
+      sizeof(wchar_t);
+
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (Length >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint("{}: MaxCount >= COMPCOV_MAX_CMP_LENGTH\n", __func__);
+    return;
+  }
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("Wcscmp(\"{}\", \"{}\", {}) -> {:#x}\n",
+               BytesToHexString(Wstr1.data(), Length),
+               BytesToHexString(Wstr2.data(), Length), Length, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Wstr1.data(), Wstr2.data(), Length);
+}
+
+//
+// Wcscmp hook.
+//
+
+void CompcovHookWcscmp(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  Gva_t Wstr1Ptr = Gva_t(Backend->GetArg(0));
+  Gva_t Wstr2Ptr = Gva_t(Backend->GetArg(1));
+
+  CompcovHandleWcscmp(Backend, Wstr1Ptr, Wstr2Ptr);
+}
+
+//
+// Generic handler for wcsncmp-like functions.
+//
+
+void CompcovHandleWcsncmp(Backend_t *Backend, Gva_t Wstr1Ptr, Gva_t Wstr2Ptr,
+                          uint64_t MaxCount) {
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (MaxCount * sizeof(wchar_t) >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint(
+        "{}: MaxCount * sizeof(wchar_t) >= COMPCOV_MAX_CMP_LENGTH / 2\n",
+        __func__);
+    return;
+  }
+
+  //
+  // Read the strings.
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Wstr1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Wstr2{};
+
+  bool Wstr1ReadRes = Backend->VirtRead(Wstr1Ptr, Wstr1.data(), MaxCount);
+  bool Wstr2ReadRes = Backend->VirtRead(Wstr2Ptr, Wstr2.data(), MaxCount);
+
+  //
+  // Check whether we were able to read the strings.
+  //
+
+  if (!Wstr1ReadRes || !Wstr2ReadRes) {
+    CompcovPrint("{}: Failed to read strings\n", __func__);
+    return;
+  }
+
+  uint64_t Length =
+      CompcovStrlen2((uint16_t *)Wstr1.data(), (uint16_t *)Wstr2.data(),
+                     COMPCOV_MAX_CMP_LENGTH / 2) *
+      sizeof(wchar_t);
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("Wcsncmp(\"{}\", \"{}\", {}) -> {:#x}\n",
+               BytesToHexString(Wstr1.data(), Length),
+               BytesToHexString(Wstr2.data(), Length), Length, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Wstr1.data(), Wstr2.data(), Length);
+}
+
+//
+// Wcsncmp hook.
+//
+
+void CompcovHookWcsncmp(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  Gva_t Wstr1Ptr = Gva_t(Backend->GetArg(0));
+  Gva_t Wstr2Ptr = Gva_t(Backend->GetArg(1));
+  uint64_t MaxCount = Backend->GetArg(2);
+
+  CompcovHandleWcsncmp(Backend, Wstr1Ptr, Wstr2Ptr, MaxCount);
+}
+
+//
+// Generic hook for CompareStringA. We ignore all the flags, custom locales,
+// and anything else. The only thing that matters is whether the strings are
+// equal or not.
+//
+
+void CompcovHookCompareStringA(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  uint32_t DwCmpFlags = Backend->GetArg(1);
+  Gva_t LpString1 = Gva_t(Backend->GetArg(2));
+  int32_t String1Length = Backend->GetArg(3);
+  Gva_t LpString2 = Gva_t(Backend->GetArg(4));
+  int32_t String2Length = Backend->GetArg(5);
+
+  //
+  // CompareStringA() might be called with a negative length, which means that
+  // the string is null-terminated, and the length should be calculated
+  // manually.
+  //
+  if (String1Length < 0) {
+    String1Length = COMPCOV_MAX_CMP_LENGTH - 1;
+  }
+
+  if (String2Length < 0) {
+    String2Length = COMPCOV_MAX_CMP_LENGTH - 1;
+  }
+
+  //
+  // Make sure that the length is not too long.
+  //
+  String1Length = std::min(String1Length, (int32_t)COMPCOV_MAX_CMP_LENGTH - 1);
+  String2Length = std::min(String2Length, (int32_t)COMPCOV_MAX_CMP_LENGTH - 1);
+
+  //
+  // Read the strings.
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH + 1> Str1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH + 1> Str2{};
+
+  bool Str1ReadRes = Backend->VirtRead(LpString1, Str1.data(), String1Length);
+  bool Str2ReadRes = Backend->VirtRead(LpString2, Str2.data(), String2Length);
+
+  //
+  // Check whether we were able to read the strings.
+  //
+
+  if (!Str1ReadRes || !Str2ReadRes) {
+    CompcovPrint("{}: Failed to read strings\n", __func__);
+    return;
+  }
+
+  uint64_t LengthBytes =
+      CompcovStrlen2(Str1.data(), Str2.data(), COMPCOV_MAX_CMP_LENGTH);
+
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (LengthBytes >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint("{}: LengthBytes >= COMPCOV_MAX_CMP_LENGTH\n", __func__);
+    return;
+  }
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("CompareStringA(..., {:#x}, \"{}\", {}, \"{}\", {}) -> {:#x}\n",
+               DwCmpFlags, Str1.data(), String1Length, Str2.data(),
+               String2Length, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Str1.data(), Str2.data(), LengthBytes);
+}
+
+//
+// Generic hook for CompareStringW. We ignore all the flags, custom locales,
+// and anything else. The only thing that matters is whether the strings are
+// equal or not.
+//
+
+void CompcovHookCompareStringW(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  uint32_t DwCmpFlags = Backend->GetArg(1);
+  Gva_t LpString1 = Gva_t(Backend->GetArg(2));
+  int32_t String1Length = Backend->GetArg(3);
+  Gva_t LpString2 = Gva_t(Backend->GetArg(4));
+  int32_t String2Length = Backend->GetArg(5);
+
+  //
+  // CompareStringW() might be called with a negative length, which means that
+  // the string is null-terminated, and the length should be calculated
+  // manually.
+  //
+  const int32_t MaxLengthCh = COMPCOV_MAX_CMP_LENGTH / sizeof(wchar_t) - 1;
+
+  if (String1Length < 0) {
+    String1Length = MaxLengthCh;
+  }
+
+  if (String2Length < 0) {
+    String2Length = MaxLengthCh;
+  }
+
+  //
+  // Make sure that the length is within the limits.
+  //
+  uint32_t String1LengthBytes =
+      std::min(String1Length, MaxLengthCh) * sizeof(wchar_t);
+  uint32_t String2LengthBytes =
+      std::min(String2Length, MaxLengthCh) * sizeof(wchar_t);
+
+  //
+  // Read the strings.
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Wstr1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Wstr2{};
+
+  bool Wstr1ReadRes =
+      Backend->VirtRead(LpString1, Wstr1.data(), String1LengthBytes);
+  bool Wstr2ReadRes =
+      Backend->VirtRead(LpString2, Wstr2.data(), String2LengthBytes);
+
+  //
+  // Check whether we were able to read the strings.
+  //
+
+  if (!Wstr1ReadRes || !Wstr2ReadRes) {
+    CompcovPrint("{}: Failed to read strings\n", __func__);
+    return;
+  }
+
+  uint64_t LengthBytes =
+      CompcovStrlen2((uint16_t *)Wstr1.data(), (uint16_t *)Wstr2.data(),
+                     COMPCOV_MAX_CMP_LENGTH / sizeof(wchar_t)) *
+      sizeof(wchar_t);
+
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (LengthBytes >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint("{}: LengthBytes >= COMPCOV_MAX_CMP_LENGTH\n", __func__);
+    return;
+  }
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("CompareStringW(..., {:#x}, \"{}\", {}, \"{}\", {}) -> {:#x}\n",
+               DwCmpFlags, BytesToHexString(Wstr1.data(), String1LengthBytes),
+               String1Length,
+               BytesToHexString(Wstr2.data(), String2LengthBytes),
+               String2Length, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Wstr1.data(), Wstr2.data(), LengthBytes);
+}
+
+//
+// Generic handler for memcmp-like functions.
+//
+
+void CompcovHandleMemcmp(Backend_t *Backend, Gva_t Buf1Ptr, Gva_t Buf2Ptr,
+                         uint64_t Size) {
+  //
+  // Skip if the comparison is too long, as we don't want to clutter the
+  // coverage database.
+  //
+
+  if (Size >= COMPCOV_MAX_CMP_LENGTH) {
+    CompcovPrint("{}: Size >= COMPCOV_MAX_CMP_LENGTH\n", __func__);
+    return;
+  }
+
+  //
+  // Read the buffers.
+  //
+
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Buf1{};
+  std::array<uint8_t, COMPCOV_MAX_CMP_LENGTH> Buf2{};
+
+  bool Buf1ReadRes = Backend->VirtRead(Buf1Ptr, Buf1.data(), Size);
+  bool Buf2ReadRes = Backend->VirtRead(Buf2Ptr, Buf2.data(), Size);
+
+  //
+  // Check whether we were able to read the buffers.
+  //
+
+  if (!Buf1ReadRes || !Buf2ReadRes) {
+    CompcovPrint("{}: Failed to read buffers\n", __func__);
+    return;
+  }
+
+  //
+  // As the breakpoint is set on the beginning of the function, we should be
+  // able to extract the return address by reading the first QWORD from the
+  // stack.
+  //
+
+  uint64_t RetLoc = Backend->VirtRead8(Gva_t(Backend->Rsp()));
+
+  CompcovPrint("Memcmp(\"{}\", \"{}\", {}) -> {:#x}\n",
+               BytesToHexString(Buf1.data(), Size),
+               BytesToHexString(Buf2.data(), Size), Size, RetLoc);
+
+  //
+  // If the return location is 0, then the VirtRead8() failed.
+  //
+
+  if (RetLoc == 0) {
+    CompcovPrint("{}: RetLoc == 0\n", __func__);
+    return;
+  }
+
+  CompcovTrace(RetLoc, Buf1.data(), Buf2.data(), Size);
+}
+
+//
+// Memcmp hook.
+//
+
+void CompcovHookMemcmp(Backend_t *Backend) {
+  //
+  // Extract the arguments.
+  //
+
+  Gva_t Buf1Ptr = Gva_t(Backend->GetArg(0));
+  Gva_t Buf2Ptr = Gva_t(Backend->GetArg(1));
+  uint64_t Size = Backend->GetArg(2);
+
+  CompcovHandleMemcmp(Backend, Buf1Ptr, Buf2Ptr, Size);
+}
+
+struct CompcovHook_t {
+  const std::vector<std::string_view> FunctionNames;
+  void (*HookFunction)(Backend_t *);
+};
+
+bool CompcovSetupHooks() {
+  const std::vector<std::string_view> strcmp_functions = {"ntdll!strcmp",
+                                                          "ucrtbase!strcmp"};
+  const std::vector<std::string_view> strncmp_functions = {"ntdll!strncmp",
+                                                           "ucrtbase!strncmp"};
+  const std::vector<std::string_view> wcscmp_functions = {"ntdll!wcscmp",
+                                                          "ucrtbase!wcscmp"};
+  const std::vector<std::string_view> wcsncmp_functions = {"ntdll!wcsncmp",
+                                                           "ucrtbase!wcsncmp"};
+  const std::vector<std::string_view> memcmp_functions = {
+      "ntdll!memcmp", "vcruntime140!memcmp", "ucrtbase!memcmp",
+      // RtlCompareMemory() behaves like memcmp(), so we can reuse the same
+      // hook.
+      "ntdll!RtlCompareMemory"};
+
+  const std::vector<CompcovHook_t> hooks = {
+      {strcmp_functions, CompcovHookStrcmp},
+      {strncmp_functions, CompcovHookStrncmp},
+      {wcscmp_functions, CompcovHookWcscmp},
+      {wcsncmp_functions, CompcovHookWcsncmp},
+      {{"KernelBase!CompareStringA"}, CompcovHookCompareStringA},
+      {{"KernelBase!CompareStringW"}, CompcovHookCompareStringW},
+      // CompareStringEx is essentially the same as CompareStringW, so we can
+      // reuse the same hook.
+      {{"KernelBase!CompareStringEx"}, CompcovHookCompareStringW},
+      {memcmp_functions, CompcovHookMemcmp},
+  };
+
+  bool Success = true;
+
+  for (auto &hook : hooks) {
+    for (auto &function : hook.FunctionNames) {
+      CompcovPrint("Hooking comparison function {}\n", function);
+
+      // @TODO: Currently we're "ignoring" the fact that SetBreakpoint can
+      // fail (e.g. a breakpoint is already set on the function). Probably,
+      // the best way to handle this is to replace already set breakpoint with
+      // our own, but call the original BP-handler from it. Anyways, for now
+      // it's not a problem, as we're using Bochs, which uses edge/non-bp
+      // coverage.
+      if (!g_Backend->SetBreakpoint(function.data(), hook.HookFunction)) {
+        fmt::print("Failed to SetBreakpoint on {}\n", function);
+        Success = false;
+      }
+    }
+  }
+
+  return Success;
+}
+
+//
+// Setup compcov-strcmp hook for a custom implementation of strcmp.
+//
+
+bool CompcovSetupCustomStrcmpHook(const char *Symbol,
+                                  const BreakpointHandler_t Handler) {
+  const Gva_t Gva = Gva_t(g_Dbg.GetSymbol(Symbol));
+  if (Gva == Gva_t(0)) {
+    fmt::print(
+        "Could not setup compcov strcmp hook for: {}, symbol not found!\n",
+        Symbol);
+    return false;
+  }
+
+  return CompcovSetupCustomStrcmpHook(Gva, Handler);
+}
+
+bool CompcovSetupCustomStrcmpHook(const Gva_t Gva,
+                                  const BreakpointHandler_t Handler) {
+  BochscpuBackend_t *BochsBackend =
+      dynamic_cast<BochscpuBackend_t *>(g_Backend);
+  if (!BochsBackend) {
+    fmt::print("CompcovSetupCustomHook: Unsupported backend, only BochsCPU "
+               "backend is supported\n");
+    return false;
+  }
+
+  return g_Backend->SetBreakpoint(Gva, Handler);
+}
+
+//
+// Setup compcov-strncmp hook for a custom implementation of strncmp.
+//
+
+bool CompcovSetupCustomStrncmpHook(const char *Symbol,
+                                   const BreakpointHandler_t Handler) {
+  const Gva_t Gva = Gva_t(g_Dbg.GetSymbol(Symbol));
+  if (Gva == Gva_t(0)) {
+    fmt::print(
+        "Could not setup compcov strncmp hook for: {}, symbol not found!\n",
+        Symbol);
+    return false;
+  }
+
+  return CompcovSetupCustomStrncmpHook(Gva, Handler);
+}
+
+bool CompcovSetupCustomStrncmpHook(const Gva_t Gva,
+                                   const BreakpointHandler_t Handler) {
+  BochscpuBackend_t *BochsBackend =
+      dynamic_cast<BochscpuBackend_t *>(g_Backend);
+  if (!BochsBackend) {
+    fmt::print("CompcovSetupCustomHook: Unsupported backend, only BochsCPU "
+               "backend is supported\n");
+    return false;
+  }
+
+  return g_Backend->SetBreakpoint(Gva, Handler);
+}
+
+//
+// Setup compcov-wcscmp hook for a custom implementation of wcscmp.
+//
+
+bool CompcovSetupCustomWcscmpHook(const char *Symbol,
+                                  const BreakpointHandler_t Handler) {
+  const Gva_t Gva = Gva_t(g_Dbg.GetSymbol(Symbol));
+  if (Gva == Gva_t(0)) {
+    fmt::print(
+        "Could not setup compcov wcscmp hook for: {}, symbol not found!\n",
+        Symbol);
+    return false;
+  }
+
+  return CompcovSetupCustomWcscmpHook(Gva, Handler);
+}
+
+bool CompcovSetupCustomWcscmpHook(const Gva_t Gva,
+                                  const BreakpointHandler_t Handler) {
+  BochscpuBackend_t *BochsBackend =
+      dynamic_cast<BochscpuBackend_t *>(g_Backend);
+  if (!BochsBackend) {
+    fmt::print("CompcovSetupCustomHook: Unsupported backend, only BochsCPU "
+               "backend is supported\n");
+    return false;
+  }
+
+  return g_Backend->SetBreakpoint(Gva, Handler);
+}
+
+//
+// Setup compcov-wcsncmp hook for a custom implementation of wcsncmp.
+//
+
+bool CompcovSetupCustomWcsncmpHook(const char *Symbol,
+                                   const BreakpointHandler_t Handler) {
+  const Gva_t Gva = Gva_t(g_Dbg.GetSymbol(Symbol));
+  if (Gva == Gva_t(0)) {
+    fmt::print(
+        "Could not setup compcov wcsncmp hook for: {}, symbol not found!\n",
+        Symbol);
+    return false;
+  }
+
+  return CompcovSetupCustomWcsncmpHook(Gva, Handler);
+}
+
+bool CompcovSetupCustomWcsncmpHook(const Gva_t Gva,
+                                   const BreakpointHandler_t Handler) {
+  BochscpuBackend_t *BochsBackend =
+      dynamic_cast<BochscpuBackend_t *>(g_Backend);
+  if (!BochsBackend) {
+    fmt::print("CompcovSetupCustomHook: Unsupported backend, only BochsCPU "
+               "backend is supported\n");
+    return false;
+  }
+
+  return g_Backend->SetBreakpoint(Gva, Handler);
+}
+
+//
+// Setup compcov-memcmp hook for a custom implementation of memcmp.
+//
+
+bool CompcovSetupCustomMemcmpHook(const char *Symbol,
+                                  const BreakpointHandler_t Handler) {
+  const Gva_t Gva = Gva_t(g_Dbg.GetSymbol(Symbol));
+  if (Gva == Gva_t(0)) {
+    fmt::print(
+        "Could not setup compcov memcmp hook for: {}, symbol not found!\n",
+        Symbol);
+    return false;
+  }
+
+  return CompcovSetupCustomMemcmpHook(Gva, Handler);
+}
+
+bool CompcovSetupCustomMemcmpHook(const Gva_t Gva,
+                                  const BreakpointHandler_t Handler) {
+  BochscpuBackend_t *BochsBackend =
+      dynamic_cast<BochscpuBackend_t *>(g_Backend);
+  if (!BochsBackend) {
+    fmt::print("CompcovSetupCustomHook: Unsupported backend, only BochsCPU "
+               "backend is supported\n");
+    return false;
+  }
+
+  return g_Backend->SetBreakpoint(Gva, Handler);
+}

--- a/src/wtf/compcov.h
+++ b/src/wtf/compcov.h
@@ -1,0 +1,88 @@
+// Theodor Arsenij 'm4drat' - May 26 2023
+
+#pragma once
+
+//
+// Compcov maximum comparison length. Everything above this length will be
+// ignored.
+//
+
+constexpr uint64_t COMPCOV_MAX_CMP_LENGTH = 34;
+
+//
+// Setup compcov hooks on different implementations of comparison functions:
+// ntdll!strcmp, ucrtbase!strcmp, etc.
+//
+
+bool CompcovSetupHooks();
+
+//
+// Generic compcov handlers for different comparison functions. They might be
+// useful if you want to add support for a custom comparison function, even if
+// it uses a different calling convention. Just wrap the handler into a
+// BreakpointHandler_t and use SetupCustom*Hook() functions.
+//
+
+void CompcovHandleStrcmp(Backend_t *Backend, Gva_t Str1Ptr, Gva_t Str2Ptr);
+void CompcovHandleStrncmp(Backend_t *Backend, Gva_t Str1Ptr, Gva_t Str2Ptr,
+                          uint64_t MaxCount);
+void CompcovHandleWcscmp(Backend_t *Backend, Gva_t Wstr1Ptr, Gva_t Wstr2Ptr);
+void CompcovHandleWcsncmp(Backend_t *Backend, Gva_t Wstr1Ptr, Gva_t Wstr2Ptr,
+                          uint64_t MaxCount);
+void CompcovHandleMemcmp(Backend_t *Backend, Gva_t Buf1Ptr, Gva_t Buf2Ptr,
+                         uint64_t Size);
+
+//
+// Setup compcov-strcmp hook for a custom implementation of strcmp.
+//
+
+void CompcovHookStrcmp(Backend_t *Backend);
+
+bool CompcovSetupCustomStrcmpHook(
+    const char *Symbol, const BreakpointHandler_t Handler = CompcovHookStrcmp);
+bool CompcovSetupCustomStrcmpHook(
+    const Gva_t Gva, const BreakpointHandler_t Handler = CompcovHookStrcmp);
+
+//
+// Setup compcov-strncmp hook for a custom implementation of strncmp.
+//
+
+void CompcovHookStrncmp(Backend_t *Backend);
+
+bool CompcovSetupCustomStrncmpHook(
+    const char *Symbol, const BreakpointHandler_t Handler = CompcovHookStrncmp);
+bool CompcovSetupCustomStrncmpHook(
+    const Gva_t Gva, const BreakpointHandler_t Handler = CompcovHookStrncmp);
+
+//
+// Setup compcov-wcscmp hook for a custom implementation of wcscmp.
+//
+
+void CompcovHookWcscmp(Backend_t *Backend);
+
+bool CompcovSetupCustomWcscmpHook(
+    const char *Symbol, const BreakpointHandler_t Handler = CompcovHookWcscmp);
+bool CompcovSetupCustomWcscmpHook(
+    const Gva_t Gva, const BreakpointHandler_t Handler = CompcovHookWcscmp);
+
+//
+// Setup compcov-wcsncmp hook for a custom implementation of wcsncmp.
+//
+
+void CompcovHookWcsncmp(Backend_t *Backend);
+
+bool CompcovSetupCustomWcsncmpHook(
+    const char *Symbol, const BreakpointHandler_t Handler = CompcovHookWcsncmp);
+bool CompcovSetupCustomWcsncmpHook(
+    const Gva_t Gva, const BreakpointHandler_t Handler = CompcovHookWcsncmp);
+
+//
+// Setup compcov-memcmp hook for a custom implementation of memcmp.
+//
+
+void CompcovHookMemcmp(Backend_t *Backend);
+
+bool CompcovSetupCustomMemcmpHook(
+    const char *Symbol, const BreakpointHandler_t Handler = CompcovHookMemcmp);
+bool CompcovSetupCustomMemcmpHook(
+    const Gva_t Gva, const BreakpointHandler_t Handler = CompcovHookMemcmp);

--- a/src/wtf/fuzzer_goat.cc
+++ b/src/wtf/fuzzer_goat.cc
@@ -1,0 +1,67 @@
+// Theodor Arsenij 'm4drat' - May 23 2023
+
+#include "backend.h"
+#include "crash_detection_umode.h"
+#include "targets.h"
+
+#include <fmt/format.h>
+
+namespace FuzzyGoat {
+
+constexpr bool LoggingOn = false;
+
+template <typename... Args_t>
+void DebugPrint(const char *Format, const Args_t &...args) {
+  if constexpr (LoggingOn) {
+    fmt::print("FuzzyGoat: ");
+    fmt::print(fmt::runtime(Format), args...);
+  }
+}
+
+bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
+  if (BufferSize > 0x1000 || BufferSize < 112) {
+    DebugPrint("Invalid BufferSize\n");
+    return true;
+  }
+
+  // Write payload
+  const Gva_t BufferPtr = Gva_t(g_Backend->Rcx());
+  if (!g_Backend->VirtWriteDirty(BufferPtr, Buffer, BufferSize)) {
+    DebugPrint("VirtWriteDirty failed\n");
+    return false;
+  }
+
+  // Set size
+  g_Backend->Rdx(BufferSize);
+
+  return true;
+}
+
+bool Init(const Options_t &Opts, const CpuState_t &) {
+  const Gva_t Rip = Gva_t(g_Backend->Rip());
+  const Gva_t AfterCall = Rip + Gva_t(5);
+  if (!g_Backend->SetBreakpoint(AfterCall, [](Backend_t *Backend) {
+        DebugPrint("Back from call!\n");
+        Backend->Stop(Ok_t());
+      })) {
+    DebugPrint("Failed to SetBreakpoint AfterCall\n");
+    return false;
+  }
+
+  if (!SetupUsermodeCrashDetectionHooks()) {
+    DebugPrint("Failed to SetupUsermodeCrashDetectionHooks\n");
+    return false;
+  }
+
+  return true;
+}
+
+//
+// Register the target.
+//
+
+Target_t FuzzyGoat(
+    "fuzzy_goat", Init, InsertTestcase, []() { return true; },
+    HonggfuzzMutator_t::Create);
+
+} // namespace FuzzyGoat

--- a/src/wtf/globals.h
+++ b/src/wtf/globals.h
@@ -8,6 +8,8 @@
 #include <string_view>
 #include <variant>
 
+#include "gxa.h"
+
 //
 // warning C4201: nonstandard extension used: nameless struct/union
 //
@@ -1187,6 +1189,17 @@ enum class TraceType_t {
 
 enum class BackendType_t { Bochscpu, Whv, Kvm };
 
+//
+// LAF/Compcov supported modes.
+//
+
+enum class LafCompcovOptions_t {
+  Disabled,
+  OnlyUser,
+  OnlyKernel,
+  KernelAndUser
+};
+
 struct FuzzOptions_t {
 
   //
@@ -1364,6 +1377,24 @@ struct Options_t {
   //
 
   bool Edges = false;
+
+  //
+  // Use compare coverage (memcmp, strcmp, ...) (only with bxcpu).
+  //
+
+  bool Compcov = false;
+
+  //
+  // Use LAF split-compares (only with bxcpu).
+  //
+
+  LafCompcovOptions_t Laf = LafCompcovOptions_t::Disabled;
+
+  //
+  // LAF allowed ranges.
+  //
+
+  std::vector<std::pair<Gva_t, Gva_t>> LafAllowedRanges;
 
   //
   // Options for the subcommand 'run'.

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -2087,6 +2087,14 @@ bool KvmBackend_t::RevokeLastNewCoverage() {
   return true;
 }
 
+bool KvmBackend_t::InsertCoverageEntry(const Gva_t Gva) {
+  // TODO: implement
+
+  throw std::runtime_error(__func__ + std::string("is not implemented"));
+
+  return false;
+}
+
 bool KvmBackend_t::RegisterMemory(const KvmMemoryRegion_t &MemoryRegion) {
   if (ioctl(Vm_, KVM_SET_USER_MEMORY_REGION, &MemoryRegion.Kvm) < 0) {
     perror("Cannot RegisterMemory");

--- a/src/wtf/kvm_backend.h
+++ b/src/wtf/kvm_backend.h
@@ -404,6 +404,8 @@ public:
 
   bool RevokeLastNewCoverage() override;
 
+  bool InsertCoverageEntry(const Gva_t Gva) override;
+
 private:
   //
   // Load the CPU state into the VP.

--- a/src/wtf/mutator.cc
+++ b/src/wtf/mutator.cc
@@ -106,6 +106,9 @@ size_t HonggfuzzMutator_t::Mutate(uint8_t *Data, const size_t DataLen,
 }
 
 void HonggfuzzMutator_t::OnNewCoverage(const Testcase_t &Testcase) {
+  // Update the last coverage update time.
+  Run_.global->timing.lastCovUpdate = time(nullptr);
+
   Run_.RandomBuffer = std::make_unique<uint8_t[]>(Testcase.BufferSize_);
   Run_.RandomBufferSize = Testcase.BufferSize_;
   memcpy(Run_.RandomBuffer.get(), Testcase.Buffer_.get(),

--- a/src/wtf/utils.h
+++ b/src/wtf/utils.h
@@ -21,10 +21,29 @@ using span_u8 = std::span<uint8_t>;
 const size_t StringMaxSize = 120;
 
 //
+// Hashing functions.
+//
+
+inline uint64_t SplitMix64(uint64_t Val) {
+  Val ^= Val >> 30;
+  Val *= 0xbf58476d1ce4e5b9U;
+  Val ^= Val >> 27;
+  Val *= 0x94d049bb133111ebU;
+  Val ^= Val >> 31;
+  return Val;
+}
+
+//
 // Compare two file path by their sizes.
 //
 
 [[nodiscard]] bool CompareTwoFileBySize(const fs::path &A, const fs::path &B);
+
+//
+// Bytes to hex string.
+//
+
+std::string BytesToHexString(const uint8_t *Bytes, uint32_t Length);
 
 //
 // Hexdump function.
@@ -34,6 +53,12 @@ void Hexdump(const span_u8 Buffer);
 void Hexdump(const uint64_t Address, const span_u8 Buffer);
 void Hexdump(const uint64_t Address, const void *Buffer, size_t Len);
 
+//
+// Parse LAF allowed ranges cmdline argument.
+//
+
+std::vector<std::pair<Gva_t, Gva_t>>
+ParseLafAllowedRanges(const std::string &input);
 //
 // Populate a bochscpu_state_t from a JSON file.
 //

--- a/src/wtf/whv_backend.cc
+++ b/src/wtf/whv_backend.cc
@@ -112,7 +112,8 @@ bool WhvBackend_t::Initialize(const Options_t &Opts,
 
   HRESULT Hr = WHvCreatePartition(&Partition_);
   if (FAILED(Hr)) {
-    fmt::print("Failed WHvCreatePartition (Windows Hypervisor Platform enabled?)\n");
+    fmt::print(
+        "Failed WHvCreatePartition (Windows Hypervisor Platform enabled?)\n");
     return false;
   }
 
@@ -1312,6 +1313,14 @@ bool WhvBackend_t::RevokeLastNewCoverage() {
 
   Coverage_.clear();
   return true;
+}
+
+bool WhvBackend_t::InsertCoverageEntry(const Gva_t Gva) {
+  // TODO: implement
+
+  throw std::runtime_error(__func__ + std::string("is not implemented"));
+
+  return false;
 }
 
 void WhvBackend_t::PrintRunStats() { RunStats_.Print(); }

--- a/src/wtf/whv_backend.h
+++ b/src/wtf/whv_backend.h
@@ -55,7 +55,7 @@ struct WhvBreakpoint_t {
 };
 
 //
-// This is the WHV backent. It runs test cases inside an Hyper-V backed VM.
+// This is the WHV backend. It runs test cases inside an Hyper-V backed VM.
 //
 
 class WhvBackend_t : public Backend_t {
@@ -306,6 +306,8 @@ public:
   const tsl::robin_set<Gva_t> &LastNewCoverage() const override;
 
   bool RevokeLastNewCoverage() override;
+
+  bool InsertCoverageEntry(const Gva_t Gva) override;
 
 private:
   HRESULT


### PR DESCRIPTION
Hi!
This summer I've worked on adding LAF/Compcov support for WTF. This pull-request is the essence of this experiment. I tried to make the code as "production"-ready as possible but I'm sure there is still a long way to go. I'm sending this PR because at the moment I don't have any time to work on it any further.

LAF/Compcov mode allows to solve some basic CMP-related fuzz-blockers by splitting them into multiple comparisons of smaller sizes. With the proposed implementation of the LAF/Compcov mode, WTF was able to solve all the challenges from this "benchmark": [fuzzy_goat.cc](https://github.com/m4drat/wtf/blob/fc6e8ee959c4fda9ca330d519510e8e36e6de1a1/src/fuzzy_goat/fuzzy_goat.cc) and crash the program:
![wtf-laf-found-crash](https://github.com/0vercl0k/wtf/assets/39669467/189ee5f4-b02a-49e7-a8e9-02cd409d2c7f)

An alternative implementations of this technique can be found in the qemuafl's source code: [qemuafl/cpu-translate.h](https://github.com/AFLplusplus/qemuafl/blob/a1321713c7502c152dd7527555e0f8a800d55225/qemuafl/cpu-translate.h)

I did some basic evaluation of the proposed approach (only on one target - [rizin](https://github.com/rizinorg/rizin/)), and it _kinda_ works but honestly speaking I was expecting a little bit more :) (maybe if it's tested on other targets it will show better results but who knows).

All the experimental-evaluation stuff can be found in the `./scripts/` folder. The experiment I've conducted consisted of running a bunch of WTF instances with and w/o the LAF/Compcov mode. To be precise, I had 2 instances running with LAF/Compcov support (Bochs backend), and 6 instances running on the KVM backend. The experiment was repeated 5 times each one was running for 6 hours on a PC with Ubuntu, and Intel I5 processor (don't remember the exact model).

Coverage mean:

![coverage](https://github.com/0vercl0k/wtf/assets/39669467/078138f4-8087-4b53-b7df-be41c0a25917)

Execs/sec:

![execs-sec](https://github.com/0vercl0k/wtf/assets/39669467/a33e268e-f8ed-4fda-b870-8f61a22c06ae)

Corpus size:

![corpus-size](https://github.com/0vercl0k/wtf/assets/39669467/8f089b7b-b722-4165-b8d3-d33652d53788)

The error bands here show +-1 std from the mean.

The conclusion I get from this evaluation is that it's not possible to say whether the LAF/Compcov mode really helps to fuzz Rizin, however it might show drastically better results on other targets.

Changes summary:

- Added LAF/Compcov mode for the WTF (options: `--laf`, `--compcov`, `--laf-allowed-ranges`)
- Added some basics scripts to run the experiments
- Fixes for the `gen_coverage_*` scripts
- Added basic logging functionality for the master instance
