### PR TITLE
Explicitly pass the size of the requested arguments

### DIFF
--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -175,7 +175,23 @@ Gva_t Backend_t::GetArgAddress(const uint64_t Idx) {
   return Gva_t(Rsp() + (8 + (Idx * 8)));
 }
 
-uint64_t Backend_t::GetArg(const uint64_t Idx) {
+uint32_t Backend_t::GetArg4(const uint64_t Idx) {
+  switch (Idx) {
+  case 0:
+    return (uint32_t)Rcx();
+  case 1:
+    return (uint32_t)Rdx();
+  case 2:
+    return (uint32_t)R8();
+  case 3:
+    return (uint32_t)R9();
+  default: {
+    return VirtRead4(GetArgAddress(Idx));
+  }
+  }
+}
+
+uint64_t Backend_t::GetArg8(const uint64_t Idx) {
   switch (Idx) {
   case 0:
     return Rcx();
@@ -191,10 +207,14 @@ uint64_t Backend_t::GetArg(const uint64_t Idx) {
   }
 }
 
-Gva_t Backend_t::GetArgGva(const uint64_t Idx) { return Gva_t(GetArg(Idx)); }
+Gva_t Backend_t::GetArgGva(const uint64_t Idx) { return Gva_t(GetArg8(Idx)); }
 
-std::pair<uint64_t, Gva_t> Backend_t::GetArgAndAddress(const uint64_t Idx) {
-  return {GetArg(Idx), GetArgAddress(Idx)};
+std::pair<uint32_t, Gva_t> Backend_t::GetArg4AndAddress(const uint64_t Idx) {
+  return {GetArg4(Idx), GetArgAddress(Idx)};
+}
+
+std::pair<uint64_t, Gva_t> Backend_t::GetArg8AndAddress(const uint64_t Idx) {
+  return {GetArg8(Idx), GetArgAddress(Idx)};
 }
 
 std::pair<Gva_t, Gva_t> Backend_t::GetArgAndAddressGva(const uint64_t Idx) {

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -489,7 +489,8 @@ public:
   // calling convention.
   //
 
-  [[nodiscard]] uint64_t GetArg(const uint64_t Idx);
+  [[nodiscard]] uint32_t GetArg4(const uint64_t Idx);
+  [[nodiscard]] uint64_t GetArg8(const uint64_t Idx);
   [[nodiscard]] Gva_t GetArgGva(const uint64_t Idx);
 
   //
@@ -500,7 +501,8 @@ public:
   //
 
   [[nodiscard]] Gva_t GetArgAddress(const uint64_t Idx);
-  [[nodiscard]] std::pair<uint64_t, Gva_t> GetArgAndAddress(const uint64_t Idx);
+  [[nodiscard]] std::pair<uint32_t, Gva_t> GetArg4AndAddress(const uint64_t Idx);
+  [[nodiscard]] std::pair<uint64_t, Gva_t> GetArg8AndAddress(const uint64_t Idx);
   [[nodiscard]] std::pair<Gva_t, Gva_t> GetArgAndAddressGva(const uint64_t Idx);
 
 

--- a/src/wtf/fshooks.cc
+++ b/src/wtf/fshooks.cc
@@ -116,7 +116,7 @@ bool SetupFilesystemHooks() {
         //__kernel_entry NTSTATUS NtClose(
         //  IN HANDLE Handle
         //);
-        const HANDLE Handle = HANDLE(Backend->GetArg(0));
+        const HANDLE Handle = HANDLE(Backend->GetArg8(0));
 
         FsDebugPrint("ntdll!NtClose(Handle={})\n", fmt::ptr(Handle));
 
@@ -240,16 +240,16 @@ bool SetupFilesystemHooks() {
         //  IN ULONG              EaLength
         //);
         const Gva_t GuestFileHandle = Backend->GetArgGva(0);
-        const uint32_t DesiredAccess = uint32_t(Backend->GetArg(1));
+        const uint32_t DesiredAccess = Backend->GetArg4(1);
         const Gva_t GuestObjectAttributes = Backend->GetArgGva(2);
         const Gva_t GuestIoStatusBlock = Backend->GetArgGva(3);
-        const uint64_t GuestAllocationSize = Backend->GetArg(4);
-        const uint32_t FileAttributes = uint32_t(Backend->GetArg(5));
-        const uint32_t ShareAccess = uint32_t(Backend->GetArg(6));
-        const uint32_t CreateDisposition = uint32_t(Backend->GetArg(7));
-        const uint32_t CreateOptions = uint32_t(Backend->GetArg(8));
-        const uint64_t EaBuffer = Backend->GetArg(9);
-        const uint32_t EaLength = uint32_t(Backend->GetArg(10));
+        const uint64_t GuestAllocationSize = Backend->GetArg8(4);
+        const uint32_t FileAttributes = Backend->GetArg4(5);
+        const uint32_t ShareAccess = Backend->GetArg4(6);
+        const uint32_t CreateDisposition = Backend->GetArg4(7);
+        const uint32_t CreateOptions = Backend->GetArg4(8);
+        const uint64_t EaBuffer = Backend->GetArg8(9);
+        const uint32_t EaLength = Backend->GetArg4(10);
 
         HostObjectAttributes_t HostObjectAttributes;
         if (!HostObjectAttributes.ReadFromGuest(Backend,
@@ -378,11 +378,11 @@ bool SetupFilesystemHooks() {
         //  IN ULONG              OpenOptions
         //);
         const Gva_t GuestFileHandle = Backend->GetArgGva(0);
-        const uint32_t DesiredAccess = uint32_t(Backend->GetArg(1));
+        const uint32_t DesiredAccess = Backend->GetArg4(1);
         const Gva_t GuestObjectAttributes = Backend->GetArgGva(2);
         const Gva_t GuestIoStatusBlock = Backend->GetArgGva(3);
-        const uint32_t ShareAccess = uint32_t(Backend->GetArg(4));
-        const uint32_t OpenOptions = uint32_t(Backend->GetArg(5));
+        const uint32_t ShareAccess = Backend->GetArg4(4);
+        const uint32_t OpenOptions = Backend->GetArg4(5);
 
         HostObjectAttributes_t HostObjectAttributes;
         if (!HostObjectAttributes.ReadFromGuest(Backend,
@@ -459,12 +459,12 @@ bool SetupFilesystemHooks() {
             //  ULONG                Length,
             //  FS_INFORMATION_CLASS FsInformationClass
             //);
-            const HANDLE FileHandle = HANDLE(Backend->GetArg(0));
+            const HANDLE FileHandle = HANDLE(Backend->GetArg8(0));
             const Gva_t GuestIoStatusBlock = Backend->GetArgGva(1);
             const Gva_t GuestFsInformation = Backend->GetArgGva(2);
-            const uint32_t Length = uint32_t(Backend->GetArg(3));
+            const uint32_t Length = Backend->GetArg4(3);
             const FS_INFORMATION_CLASS FsInformationClass =
-                FS_INFORMATION_CLASS(Backend->GetArg(4));
+                FS_INFORMATION_CLASS(Backend->GetArg4(4));
 
             FsDebugPrint("ntdll!NtQueryVolumeInformationFile(FileHandle={}, "
                          "IoStatusBlock={:#x}, "
@@ -556,12 +556,12 @@ bool SetupFilesystemHooks() {
             //  ULONG                  Length,
             //  FILE_INFORMATION_CLASS FileInformationClass
             //);
-            const HANDLE FileHandle = HANDLE(Backend->GetArg(0));
+            const HANDLE FileHandle = HANDLE(Backend->GetArg8(0));
             const Gva_t GuestIoStatusBlock = Backend->GetArgGva(1);
             const Gva_t GuestFileInformation = Backend->GetArgGva(2);
-            const uint32_t Length = uint32_t(Backend->GetArg(3));
+            const uint32_t Length = Backend->GetArg4(3);
             const FILE_INFORMATION_CLASS FileInformationClass =
-                FILE_INFORMATION_CLASS(Backend->GetArg(4));
+                FILE_INFORMATION_CLASS(Backend->GetArg4(4));
 
             FsDebugPrint("ntdll!NtQueryInformationFile(FileHandle={}, "
                          "IoStatusBlock={:#x}, "
@@ -645,12 +645,12 @@ bool SetupFilesystemHooks() {
             //  ULONG                  Length,
             //  FILE_INFORMATION_CLASS FileInformationClass
             //);
-            const HANDLE FileHandle = HANDLE(Backend->GetArg(0));
+            const HANDLE FileHandle = HANDLE(Backend->GetArg8(0));
             const Gva_t GuestIoStatusBlock = Backend->GetArgGva(1);
             const Gva_t GuestFileInformation = Backend->GetArgGva(2);
-            const uint32_t Length = uint32_t(Backend->GetArg(3));
+            const uint32_t Length = Backend->GetArg4(3);
             const FILE_INFORMATION_CLASS FileInformationClass =
-                FILE_INFORMATION_CLASS(Backend->GetArg(4));
+                FILE_INFORMATION_CLASS(Backend->GetArg4(4));
 
             FsDebugPrint("ntdll!NtSetInformationFile(FileHandle={}, "
                          "IoStatusBlock={:#x}, "
@@ -736,15 +736,15 @@ bool SetupFilesystemHooks() {
         //  PLARGE_INTEGER   ByteOffset,
         //  PULONG           Key
         //);
-        const HANDLE FileHandle = HANDLE(Backend->GetArg(0));
-        const uint64_t Event = Backend->GetArg(1);
-        const uint64_t ApcRoutine = Backend->GetArg(2);
-        const uint64_t ApcContext = Backend->GetArg(3);
+        const HANDLE FileHandle = HANDLE(Backend->GetArg8(0));
+        const uint64_t Event = Backend->GetArg8(1);
+        const uint64_t ApcRoutine = Backend->GetArg8(2);
+        const uint64_t ApcContext = Backend->GetArg8(3);
         const Gva_t GuestIoStatusBlock = Backend->GetArgGva(4);
         const Gva_t GuestBuffer = Backend->GetArgGva(5);
-        const uint32_t Length = uint32_t(Backend->GetArg(6));
-        const uint64_t GuestByteOffset = Backend->GetArg(7);
-        const uint64_t Key = Backend->GetArg(8);
+        const uint32_t Length = Backend->GetArg4(6);
+        const uint64_t GuestByteOffset = Backend->GetArg8(7);
+        const uint64_t Key = Backend->GetArg8(8);
 
         FsDebugPrint(
             "nt!NtWriteFile(FileHandle={}, Event={:#x}, ApcRoutine={:#x}, "
@@ -825,15 +825,15 @@ bool SetupFilesystemHooks() {
         //  _In_opt_ PLARGE_INTEGER   ByteOffset,
         //  _In_opt_ PULONG           Key
         //);
-        const HANDLE FileHandle = HANDLE(Backend->GetArg(0));
-        const uint64_t Event = Backend->GetArg(1);
-        const uint64_t ApcRoutine = Backend->GetArg(2);
-        const uint64_t ApcContext = Backend->GetArg(3);
+        const HANDLE FileHandle = HANDLE(Backend->GetArg8(0));
+        const uint64_t Event = Backend->GetArg8(1);
+        const uint64_t ApcRoutine = Backend->GetArg8(2);
+        const uint64_t ApcContext = Backend->GetArg8(3);
         const Gva_t GuestIoStatusBlock = Backend->GetArgGva(4);
         const Gva_t GuestBuffer = Backend->GetArgGva(5);
-        const uint32_t Length = uint32_t(Backend->GetArg(6));
+        const uint32_t Length = Backend->GetArg4(6);
         const Gva_t GuestByteOffset = Backend->GetArgGva(7);
-        const uint64_t Key = Backend->GetArg(8);
+        const uint64_t Key = Backend->GetArg8(8);
 
         FsDebugPrint(
             "nt!NtReadFile(FileHandle={}, Event={:#x}, ApcRoutine={:#x}, "

--- a/src/wtf/fuzzer_hevd.cc
+++ b/src/wtf/fuzzer_hevd.cc
@@ -112,12 +112,12 @@ bool Init(const Options_t &Opts, const CpuState_t &) {
   //
 
   if (!g_Backend->SetBreakpoint("nt!KeBugCheck2", [](Backend_t *Backend) {
-        const uint64_t BCode = Backend->GetArg(0);
-        const uint64_t B0 = Backend->GetArg(1);
-        const uint64_t B1 = Backend->GetArg(2);
-        const uint64_t B2 = Backend->GetArg(3);
-        const uint64_t B3 = Backend->GetArg(4);
-        const uint64_t B4 = Backend->GetArg(5);
+        const uint32_t BCode = Backend->GetArg4(0);
+        const uint64_t B0 = Backend->GetArg8(1);
+        const uint64_t B1 = Backend->GetArg8(2);
+        const uint64_t B2 = Backend->GetArg8(3);
+        const uint64_t B3 = Backend->GetArg8(4);
+        const uint64_t B4 = Backend->GetArg8(5);
         const std::string Filename =
             fmt::format("crash-{:#x}-{:#x}-{:#x}-{:#x}-{:#x}-{:#x}", BCode, B0,
                         B1, B2, B3, B4);

--- a/src/wtf/fuzzer_ioctl.cc
+++ b/src/wtf/fuzzer_ioctl.cc
@@ -75,16 +75,16 @@ bool InsertTestcase(const uint8_t *Buffer, const size_t BufferSize) {
   //
 
   const auto &[InputBufferSize, InputBufferSizePtr] =
-      g_Backend->GetArgAndAddress(7);
+      g_Backend->GetArg4AndAddress(7);
   const uint32_t MutatedInputBufferSize =
-      std::min(TotalInputBufferSize, uint32_t(InputBufferSize));
+      std::min(TotalInputBufferSize, InputBufferSize);
 
   //
   // Calculate the new InputBuffer address by pushing the mutated buffer as
   // close as possible from its end.
   //
 
-  const auto &[InputBuffer, InputBufferPtr] = g_Backend->GetArgAndAddress(6);
+  const auto &[InputBuffer, InputBufferPtr] = g_Backend->GetArg8AndAddress(6);
   const auto NewInputBuffer =
       Gva_t(InputBuffer + InputBufferSize - MutatedInputBufferSize);
 
@@ -212,12 +212,12 @@ bool Init(const Options_t &Opts, const CpuState_t &) {
   //
 
   if (!g_Backend->SetBreakpoint("nt!KeBugCheck2", [](Backend_t *Backend) {
-        const uint64_t BCode = Backend->GetArg(0);
-        const uint64_t B0 = Backend->GetArg(1);
-        const uint64_t B1 = Backend->GetArg(2);
-        const uint64_t B2 = Backend->GetArg(3);
-        const uint64_t B3 = Backend->GetArg(4);
-        const uint64_t B4 = Backend->GetArg(5);
+        const uint32_t BCode = Backend->GetArg4(0);
+        const uint64_t B0 = Backend->GetArg8(1);
+        const uint64_t B1 = Backend->GetArg8(2);
+        const uint64_t B2 = Backend->GetArg8(3);
+        const uint64_t B3 = Backend->GetArg8(4);
+        const uint64_t B4 = Backend->GetArg8(5);
         const std::string Filename =
             fmt::format("crash-{:#x}-{:#x}-{:#x}-{:#x}-{:#x}-{:#x}", BCode, B0,
                         B1, B2, B3, B4);


### PR DESCRIPTION
Due to refactoring in #155 the argument size bug was introduced.

Initially the code was like this:
https://github.com/1ndahous3/wtf/blob/a874ebaf71da4f94df1dba85fb3ca18441e96f42/src/wtf/fuzzer_ioctl.cc#L48-L56

But after refactoring it became like this:
https://github.com/0vercl0k/wtf/blob/9823579ef764b0b3c0af2f71b61d5aa47fb3de51/src/wtf/fuzzer_ioctl.cc#L77-L89

So 8 bytes are read for the `InputBufferSize` argument, and we got an invalid value - only one `uint32_t(InputBufferSize)` cast is made, but then the same cast is not made during addition operation.

This patch replaces one argument getter function with two: `GetArg4()` for 4-byte values and `GetArg8()` for 8-byte values. Also, many additional casts to `uint32_t` have been removed, which are no longer needed.