### PR TITLE
Add support for loading raw VMWare snapshots 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,11 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/libs/CLI11/include)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/libs/fmt/include)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/libs/yas/include)
 
+option(ERROR_WARN "Relax error handling , for loading vmware snapshots" OFF)
+if (ERROR_WARN)
+  add_definitions(-DERROR_WARN)
+endif()
+
 file(
     GLOB_RECURSE
     wtf_srcfiles

--- a/src/build/build-release-vmware-support.bat
+++ b/src/build/build-release-vmware-support.bat
@@ -1,0 +1,2 @@
+cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DERROR_WARN=ON
+cmake --build .

--- a/src/wtf/utils.cc
+++ b/src/wtf/utils.cc
@@ -251,7 +251,11 @@ bool SanitizeCpuState(CpuState_t &CpuState) {
     if (Seg->Reserved != ((Seg->Limit >> 16) & 0xF)) {
       fmt::print("Segment with selector {:x} has invalid attributes.\n",
                  Seg->Selector);
+      #if defined(ERROR_WARN)
+      fmt::print("Above error could be fatal, but continuing anyway.");
+      #else
       return false;
+      #endif
     }
   }
 

--- a/src/wtf/wtf.cc
+++ b/src/wtf/wtf.cc
@@ -473,8 +473,13 @@ int main(int argc, const char *argv[]) {
     //
 
     if (!g_Dbg->Init(Opts.DumpPath, Opts.SymbolFilePath)) {
+      fmt::print("WARNING: Debugger init failed.\n");
+      #if defined(ERROR_WARN)
+      fmt::print("Above error could be fatal, but continuing anyway.");
+      #else
       return EXIT_FAILURE;
-    }
+      #endif
+   }
 
     //
     // Set an instruction limit to avoid infinite loops, etc.


### PR DESCRIPTION
These patches simply add support for loading VMWare snapshots which are raw, linear, RAM dumps. 

The change in the kdump parsers is simple, if the initial parsing fails, it opportunistically tries to load the file as a raw dump, else it continues into parsing different usual kdumps types.

The second part of the patch has to do with actually loading these where I had to relax a few warnings or errors, as there's no point in trying to enable a debugger on raw memory dumps. 

To build the project with support for loading these VMWare dumps, there's a new `build-release-vmware-support.bat` script that enables the flags that relax the warnings. 

I'll have a macOS/fuzzer target and an example workflow in a separate repository.  

