### PR TITLE
Fix #210

### DIFF
--- a/src/wtf/backend.cc
+++ b/src/wtf/backend.cc
@@ -49,6 +49,7 @@ bool Backend_t::VirtRead(const Gva_t Gva, uint8_t *Buffer,
     const uint64_t Size2Read = std::min(Size, BytesReadable);
     const uint8_t *Hva = PhysTranslate(Gpa);
     memcpy(Buffer, Hva, Size2Read);
+    TrackTenetMemoryAccess(CurrentGva.U64(), Size2Read, BOCHSCPU_HOOK_MEM_READ);
     Size -= Size2Read;
     CurrentGva += Gva_t(Size2Read);
     Buffer += Size2Read;
@@ -111,6 +112,8 @@ bool Backend_t::VirtWrite(const Gva_t Gva, const uint8_t *Buffer,
     const uint64_t Size2Write = std::min(Size, BytesWriteable);
     uint8_t *Hva = PhysTranslate(Gpa);
     memcpy(Hva, Buffer, Size2Write);
+    TrackTenetMemoryAccess(CurrentGva.U64(), Size2Write,
+                           BOCHSCPU_HOOK_MEM_WRITE);
     Size -= Size2Write;
     CurrentGva += Gva_t(Size2Write);
     Buffer += Size2Write;

--- a/src/wtf/backend.h
+++ b/src/wtf/backend.h
@@ -610,6 +610,14 @@ public:
   virtual bool RevokeLastNewCoverage() = 0;
 
   //
+  // Track a memory access to be able to generate a Tenet trace.
+  //
+
+  virtual void TrackTenetMemoryAccess(const uint64_t VirtualAddress,
+                                      const uint64_t Len,
+                                      const uint32_t MemAccess) const {}
+
+  //
   // Print the registers.
   //
 

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -370,7 +370,6 @@ BochscpuBackend_t::Run(const uint8_t *Buffer, const uint64_t BufferSize) {
   // Reset Tenet state.
   //
 
-  Tenet_.MemAccesses_.clear();
   Tenet_.PastFirstInstruction_ = false;
 
   //
@@ -547,6 +546,18 @@ __declspec(safebuffers)
   }
 }
 
+void BochscpuBackend_t::TrackTenetMemoryAccess(const uint64_t VirtualAddress,
+                                               const uint64_t Len,
+                                               const uint32_t MemAccess) const {
+  //
+  // Log explicit details about the memory access if taking a full-trace.
+  //
+
+  if (TraceFile_ && TraceType_ == TraceType_t::Tenet) {
+    Tenet_.MemAccesses_.emplace_back(VirtualAddress, Len, MemAccess);
+  }
+}
+
 void BochscpuBackend_t::LinAccessHook(/*void *Context, */ uint32_t,
                                       uint64_t VirtualAddress,
                                       uint64_t PhysicalAddress, uintptr_t Len,
@@ -570,9 +581,7 @@ void BochscpuBackend_t::LinAccessHook(/*void *Context, */ uint32_t,
   // Log explicit details about the memory access if taking a full-trace.
   //
 
-  if (TraceFile_ && TraceType_ == TraceType_t::Tenet) {
-    Tenet_.MemAccesses_.emplace_back(VirtualAddress, Len, MemAccess);
-  }
+  TrackTenetMemoryAccess(VirtualAddress, Len, MemAccess);
 
   //
   // If this is not a write access, we don't care to go further.
@@ -1202,7 +1211,6 @@ MemAccessToTenetLabel(const uint32_t MemAccess) {
 
   case BOCHSCPU_HOOK_MEM_WRITE: {
     return "mw";
-    break;
   }
 
   default: {
@@ -1271,21 +1279,38 @@ void BochscpuBackend_t::DumpTenetDelta(const bool Force) {
     //
     // Fetch the memory that was read or written by the last executed
     // instruction. The largest load that can happen today is an AVX512
-    // load which is 64 bytes long.
+    // load which is 64 bytes long... unless the access is coming from a user
+    // calling `VirtWrite*` in which case the access size can be of arbitrary
+    // size.
+    //
+    // What we'll do is only allocate a heap buffer if the `AccessInfo.Len` is
+    // larger than the static buffer below; this should avoid allocating /
+    // deallocating every time we get here.
     //
 
-    std::array<uint8_t, 64> Buffer;
-    if (AccessInfo.Len > Buffer.size()) {
-      fmt::print("A memory access was bigger than {} bytes, aborting\n",
-                 AccessInfo.Len);
-      std::abort();
+    std::array<uint8_t, 64> StaticBuffer;
+    std::vector<uint8_t> DynamicBuffer;
+    uint8_t *Buffer = nullptr;
+    if (AccessInfo.Len <= StaticBuffer.size()) {
+      Buffer = StaticBuffer.data();
+    } else {
+      DynamicBuffer.resize(AccessInfo.Len);
+      Buffer = DynamicBuffer.data();
     }
 
-    if (!VirtRead(AccessInfo.VirtualAddress, Buffer.data(), AccessInfo.Len)) {
+    //
+    // Avoid reentrance by disabling tenet.
+    //
+
+    TraceType_ = TraceType_t::Rip;
+
+    if (!VirtRead(AccessInfo.VirtualAddress, Buffer, AccessInfo.Len)) {
       fmt::print("VirtRead at {:#x} failed, aborting\n",
                  AccessInfo.VirtualAddress);
       std::abort();
     }
+
+    TraceType_ = TraceType_t::Tenet;
 
     //
     // Convert the raw memory bytes to a human-readable hex string.

--- a/src/wtf/bochscpu_backend.cc
+++ b/src/wtf/bochscpu_backend.cc
@@ -1317,8 +1317,15 @@ void BochscpuBackend_t::DumpTenetDelta(const bool Force) {
     //
 
     std::string HexString;
+    HexString.reserve(AccessInfo.Len * 2);
+    const char HexDigits[] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                              '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
     for (size_t Idx = 0; Idx < AccessInfo.Len; Idx++) {
-      HexString = fmt::format("{}{:02X}", HexString, Buffer[Idx]);
+      char Hex[3];
+      Hex[0] = HexDigits[(Buffer[Idx] >> 4) & 0xf];
+      Hex[1] = HexDigits[(Buffer[Idx] >> 0) & 0xf];
+      Hex[2] = 0;
+      HexString.append(Hex);
     }
 
     //

--- a/src/wtf/bochscpu_backend.h
+++ b/src/wtf/bochscpu_backend.h
@@ -130,7 +130,7 @@ class BochscpuBackend_t : public Backend_t {
     //
 
     std::vector<BochscpuMemAccess_t> MemAccesses_;
-  } Tenet_;
+  } mutable Tenet_;
 
   //
   // The hooks we define onto the Cpu.
@@ -267,6 +267,9 @@ public:
   const tsl::robin_set<Gva_t> &LastNewCoverage() const override;
 
   bool RevokeLastNewCoverage() override;
+
+  void TrackTenetMemoryAccess(const uint64_t VirtualAddress, const uint64_t Len,
+                              const uint32_t MemAccess) const override;
 
   //
   // Hooks.

--- a/src/wtf/wtf.cc
+++ b/src/wtf/wtf.cc
@@ -151,7 +151,7 @@ int main(int argc, const char *argv[]) {
         break;
       }
 
-      case BackendType_t::Whv: {
+      case BackendType_t::Whv:
       case BackendType_t::Kvm: {
         Opts.Run.TraceType = TraceType_t::UniqueRip;
         break;

--- a/src/wtf/wtf.cc
+++ b/src/wtf/wtf.cc
@@ -150,12 +150,9 @@ int main(int argc, const char *argv[]) {
         Opts.Run.TraceType = TraceType_t::Rip;
         break;
       }
-#ifdef WINDOWS
+
       case BackendType_t::Whv: {
-#endif
-#ifdef LINUX
       case BackendType_t::Kvm: {
-#endif
         Opts.Run.TraceType = TraceType_t::UniqueRip;
         break;
       }


### PR DESCRIPTION
Artificially insert Tenet memory read/write entries when the user does memory accesses in breakpoint callbacks or anywhere else. 

If we don't do that, then Tenet "doesn't know" that a memory read (bp access wouldn't trigger) or a memory write (the memory state is 'wrong' until a memory read is done on that range to fetch the memory) happened.