### PR TITLE
Fix crash when nodes are racing to populate the symbol store

### DIFF
--- a/.github/workflows/wtf.yml
+++ b/.github/workflows/wtf.yml
@@ -13,10 +13,10 @@ jobs:
     name: Windows latest / ${{ matrix.generator }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup vs prompt
         uses: ilammy/msvc-dev-cmd@v1
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload artifacts
         if: matrix.generator == 'ninja'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bin-win64.RelWithDebInfo
           path: |
@@ -64,7 +64,7 @@ jobs:
     name: Ubuntu latest / ${{ matrix.compiler }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Installing dependencies
         run: |
@@ -93,7 +93,7 @@ jobs:
           ./build-release.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bin-lin64-${{ matrix.compiler }}.Release
           path: |

--- a/.github/workflows/wtf.yml
+++ b/.github/workflows/wtf.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Build with clang
         if: matrix.compiler == 'clang'
         env:
-          CC: clang-20
-          CXX: clang++-20
+          CC: clang-22
+          CXX: clang++-22
         run: |
           cd src/build
           chmod u+x ./build-release.sh

--- a/src/wtf/debugger.h
+++ b/src/wtf/debugger.h
@@ -150,6 +150,11 @@ public:
       SymbolFileIn >> Json;
     }
 
+    const std::string AddrStr = fmt::format("{:#x}", Address);
+    if (Json.contains(Name) && Json[Name] == AddrStr) {
+        return true;
+    }
+    
     if (Json.contains(Name)) {
       Json[Name] = fmt::format("{:#x}", Address);
     } else {

--- a/src/wtf/debugger.h
+++ b/src/wtf/debugger.h
@@ -151,14 +151,13 @@ public:
     }
 
     const std::string AddrStr = fmt::format("{:#x}", Address);
-    if (Json.contains(Name) && Json[Name] == AddrStr) {
-        return true;
-    }
-    
     if (Json.contains(Name)) {
-      Json[Name] = fmt::format("{:#x}", Address);
+      if (Json[Name] == AddrStr) {
+        return true;
+      }
+      Json[Name] = AddrStr;
     } else {
-      Json.emplace(Name, fmt::format("{:#x}", Address));
+      Json.emplace(Name, AddrStr);
     }
 
     std::ofstream SymbolFileOut(SymbolFilePath_);

--- a/src/wtf/guestfile.h
+++ b/src/wtf/guestfile.h
@@ -325,7 +325,7 @@ public:
           (FILE_ALLOCATION_INFORMATION *)HostFileInformation;
 
       FileStreamDebugPrint("FileAllocationInformation({:#x}).\n",
-                           FileAllocationInfo->AllocationSize);
+                           FileAllocationInfo_->AllocationSize);
     } else {
       FileStreamDebugPrint("Unsupported class.\n");
       return false;

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -2062,13 +2062,11 @@ uint64_t KvmBackend_t::SetReg(const Registers_t Reg, const uint64_t Value) {
 
   case Registers_t::Cr2: {
     Run_->s.regs.sregs.cr2 = Value;
-    Run_->kvm_dirty_regs |= KVM_SYNC_X86_SREGS;
     break;
   }
 
   case Registers_t::Cr3: {
     Run_->s.regs.sregs.cr3 = Value;
-    Run_->kvm_dirty_regs |= KVM_SYNC_X86_SREGS;
     break;
   }
   }

--- a/src/wtf/kvm_backend.cc
+++ b/src/wtf/kvm_backend.cc
@@ -2062,11 +2062,13 @@ uint64_t KvmBackend_t::SetReg(const Registers_t Reg, const uint64_t Value) {
 
   case Registers_t::Cr2: {
     Run_->s.regs.sregs.cr2 = Value;
+    Run_->kvm_dirty_regs |= KVM_SYNC_X86_SREGS;
     break;
   }
 
   case Registers_t::Cr3: {
     Run_->s.regs.sregs.cr3 = Value;
+    Run_->kvm_dirty_regs |= KVM_SYNC_X86_SREGS;
     break;
   }
   }


### PR DESCRIPTION
Hi, first of all thanks for this amazing tool.
Now to the bug.
I have observed the strange crash when I was trying to launch more than one client node, one of them just kept crashing.
The only output was the connection message, so at first I suspected a network issue but after attaching a debugger it shows me the real issue.

In my InsertTestcase() function I was calling g_Dbg->GetModuleBase() to get a module base from a symbol.
The problem is that this function is calling AddSymbol() under the hood that overwrites the symbol-store.json every testcase.
When second node is launched it also tries to overwrite the symbol file every testcase.
They both trying to read then overwrite the file that already contains the symbol resulting in crash.

Should I call g_Dbg->GetModuleBase inside InsertTestcase loop every time? I shouldn't.
This can be fixed by just caching the module base value and not calling this function every testcase. 
But should the g_Dbg->GetModuleBase or AddSymbol() overwrite the file every time when the symbol is already resolved with the same value? I think not.

Happy to hear any thoughts on this.
Cheers.